### PR TITLE
mentor interface without ready to build

### DIFF
--- a/challenges/templates/challenge_plan.html
+++ b/challenges/templates/challenge_plan.html
@@ -96,7 +96,9 @@
     {% for comment in comments %}
     {% include "_comment.html" %}
   {% endfor %}
+  {% if not request.user.profile.is_mentor %}
   <a class="btn btn-lg btn-primary start-link" href="{% url 'challenges:challenge_progress' challenge_id=challenge.id username=progress.student.username stage='build' %}">Ready to Build</a>
+  {% endif %}
 </div><!-- /col 2 -->
 
 </div><!-- row -->


### PR DESCRIPTION
https://trello.com/c/ltdUEwi0/129-remove-ready-to-build-button-from-mentor-interface


<!---
@huboard:{"custom_state":"archived"}
-->
