### PR TITLE
[Review] Make absolute link relative in base template

### DIFF
--- a/curiositymachine/templates/base.html
+++ b/curiositymachine/templates/base.html
@@ -102,7 +102,7 @@
   <footer class="main-column">
     <div class="container-fluid footer-content">
       <p>
-        Need help? <a href="http://www.curiositymachine.org/faq/">FAQ</a>
+        Need help? <a href="/faq/">FAQ</a>
         | Email: <a href="mailto:curiosity@iridescentlearning.org">curiosity@iridescentlearning.org</a>
         | Powered by Iridescent, a 501c3 nonprofit organization in the United States. Follow us:
           <a href="https://twitter.com/Curious_Machine"><img src="/static/images/twitter-4-32.png"></a>


### PR DESCRIPTION
Another pretty minor thing, but it can sometimes cause trouble to reference an absolute url that could be relative. For instance if you're working in staging, clicking the FAQ link would take you to production in a way that might go unnoticed. If you then continue to muck around, you might be doing things you didn't want to do on the live site.


<!---
@huboard:{"custom_state":"archived"}
-->
