### PR TITLE
Pin newrelic to recent version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ django-summernote==0.5.8
 django-bleach==0.2.0
 
 #performance monitoring
-newrelic
+newrelic==2.50.0.39
 
 #captcha
 django-recaptcha==1.0


### PR DESCRIPTION
This should close #444 just by pinning newrelic to a recent version. [This version](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-246037) mentions a fix for what sounds like the problem we're seeing.


<!---
@huboard:{"custom_state":"archived"}
-->
