### PR TITLE
Worker concurrency

### DIFF
--- a/subprocess_workers.py
+++ b/subprocess_workers.py
@@ -9,7 +9,7 @@ import signal
 import time
 from django_rq import get_scheduler
 
-NUMBER_OF_WORKERS = 4
+NUMBER_OF_WORKERS = int(os.environ.get('RQ_CONCURRENT_WORKERS', 4))
 
 commands = ['python -u manage.py rqworker'] * NUMBER_OF_WORKERS
 


### PR DESCRIPTION
Experimented with lowering worker concurrency on staging and it seemed to reduce the swap memory usage substantially. This change makes the number configurable and drops the default to 4.
