### PR TITLE
Request/response logging middleware

### DIFF
--- a/curiositymachine/middleware.py
+++ b/curiositymachine/middleware.py
@@ -43,3 +43,24 @@ class LastActiveMiddleware:
         if request.user.is_authenticated():
             request.user.profile.set_active()
         return None
+
+from time import time
+from logging import getLogger
+
+class LoggingMiddleware(object):
+    def __init__(self):
+        self.logger = getLogger('custom.RequestResponse')
+
+    def process_request(self, request):
+        self.logger.info('Starting request %s', request.get_full_path())
+        request.timer = time()
+        return None
+
+    def process_response(self, request, response):
+        self.logger.info(
+            'Finishing request %s [%s] (%.1fs)',
+            request.get_full_path(),
+            response.status_code,
+            time() - request.timer
+        )
+        return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,3 +71,6 @@ django-sslify>=0.2
 django-compressor==1.4
 
 python-dateutil==2.3
+
+# request ids on heroku for logging
+django-log-request-id==1.1.0


### PR DESCRIPTION
To help diagnose the heroku timeouts, I think we need to start logging requests as they come in and responses as they go out and look for mismatched pairs. Heroku seems to only log responses, so maybe some long-running request is timing out, putting the dyno in a bad state, and never showing up in the logs at all. Does that make sense @christensenep or am I thinking about this wrong?
