### PR TITLE
Adding staticflatpages app and example page

### DIFF
--- a/curiositymachine/settings.py
+++ b/curiositymachine/settings.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.sites',
     'django.contrib.flatpages',
+    'staticflatpages',
     'profiles',
     'challenges',
     'cmcomments',
@@ -96,6 +97,7 @@ MIDDLEWARE_CLASSES = (
     'curiositymachine.middleware.UnapprovedMentorSandboxMiddleware',
     'curiositymachine.middleware.LastActiveMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
+    'staticflatpages.middleware.StaticFlatpageFallbackMiddleware',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/curiositymachine/templates/staticflatpages/example.html
+++ b/curiositymachine/templates/staticflatpages/example.html
@@ -1,0 +1,4 @@
+{% extends "base.html" %}
+{% block content %}
+  Hi!
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,3 +71,5 @@ django-sslify>=0.2
 django-compressor==1.4
 
 python-dateutil==2.3
+
+django-staticflatpages==0.3.1


### PR DESCRIPTION
Next step of #401 

@savannahmillion take a look here, and grab this branch to start playing with staticflatpages and moving our static pages into the repo.

For now, urls like `/faq/` won't make it through to the staticflatpages templates, but get intercepted by the old pages app until it gets removed. But you can do something like build the pages out in `curiositymachine/templates/staticflatpages/temp/` and see them at `/temp/faq/` until we remove the pages url config.
