### PR TITLE
Adding membership admin section

### DIFF
--- a/groups/admin.py
+++ b/groups/admin.py
@@ -28,5 +28,12 @@ class InvitationAdmin(admin.ModelAdmin):
     model = models.Invitation
     list_display = ['id', 'group', 'user']
 
+class MembershipAdmin(admin.ModelAdmin):
+    model = models.Membership
+    list_display = ['group', 'user', 'role']
+    list_filter = ['role']
+    search_fields = ['group__name', 'user__username']
+
 admin.site.register(models.Group, GroupAdmin)
 admin.site.register(models.Invitation, InvitationAdmin)
+admin.site.register(models.Membership, MembershipAdmin)


### PR DESCRIPTION
Adding a Membership admin section provides a simple alternative to going into the slow-loading group screens to change group membership. We can have that alongside everything else right now and see if it's helpful.

<!---
@huboard:{"order":524.0,"milestone_order":498,"custom_state":"archived"}
-->
