### PR TITLE
consider staff account an approved viewer in decorator

### DIFF
--- a/curiositymachine/decorators.py
+++ b/curiositymachine/decorators.py
@@ -17,7 +17,8 @@ def mentor_or_current_user(view):
 def current_user_or_approved_viewer(view):
     @wraps(view)
     def inner(request, challenge_id, username, *args, **kwargs):
-        if (request.user.profile.is_mentor
+        if (request.user.is_staff
+                or request.user.profile.is_mentor
                 or request.user.username == username
                 or Membership.users_share_any_group(request.user.username, Role.owner, username, Role.member)
                 or request.user.profile.is_parent_of(username, active=True, removed=False)):


### PR DESCRIPTION
The "view on site" button for Progress objects was redirecting to inspiration; this allows staff accounts to see progresses.

<!---
@huboard:{"order":546.0,"milestone_order":539,"custom_state":""}
-->
