### PR TITLE
Adding maintenance page to repo with note on Heroku usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ Run `make test` to run tests.
 
 Test coverage can be generated with `make coverage` or `coverage.sh` for a command-line report,
 or to generate an HTML report in `./htmlcov/index.html` use `make cov` or `make htmlcov`.
+
+## Error Pages
+
+Error pages under `curiositymachine/static/errors/` can be used on Heroku as specified [here](https://devcenter.heroku.com/articles/error-pages). 

--- a/curiositymachine/static/errors/README.md
+++ b/curiositymachine/static/errors/README.md
@@ -1,0 +1,1 @@
+For use on Heroku: https://devcenter.heroku.com/articles/error-pages

--- a/curiositymachine/static/errors/astronaut.svg
+++ b/curiositymachine/static/errors/astronaut.svg
@@ -1,0 +1,1487 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 955 620" enable-background="new 0 0 955 620" xml:space="preserve">
+<g id="Layer_2" display="none">
+	<rect x="-146.3" y="-878.8" display="inline" fill="#1A3437" width="1327" height="753.6"/>
+</g>
+<g id="Layer_1">
+	<path fill="#29B9C9" d="M1621-621.7h-57.3c-1.8-4.4-6.1-7.5-11.1-7.5h-0.3c-4.2-22.5-23.9-39.6-47.6-39.6h-21.1
+		c-23.7,0-43.4,17.1-47.6,39.6h-0.3c-6.6,0-12,5.4-12,12v13.2c0,6.6,5.4,12,12,12h2.2c3.9,11,11.8,20.2,21.8,25.9
+		c0.1-0.2,0.3-0.3,0.5-0.5c-1.1,1-1.9,2.3-2.1,3.8c-8.9,2.4-16.2,8.6-20,16.8c0-0.1,0.1-0.1,0.1-0.2l-45.1,45.1l-8.2-8.2l-9.9-9.9
+		l-7.2-7.2c-4.3-4.3-10-6.6-16-6.6h0c-6,0-11.7,2.4-16,6.6c-8.8,8.8-8.8,23.2,0,32l23.1,23.1l16.6,16.6c0,0,0,0,0,0l1.4,1.4l0,0
+		c0,0,0,0,0.1,0.1c2.8,2.8,6.2,4.8,10,5.8c0.5,0.1,1.1,0.3,1.6,0.4c1.5,0.3,2.9,0.4,4.5,0.4c5.7,0,11.1-2.1,15.3-6
+		c0.3-0.1,0.6-0.3,0.9-0.5l1.9-1.9c0,0,0,0,0,0l24.1-24.1v38.7l-25.2,25.2l-9.9,9.9l-7.3,7.3c0,0,0,0,0,0l-4.7,4.7
+		c-3,3-5.3,6.7-6.6,10.8c-1.3,3.2-2,6.7-2,10.2v7.2v20.7v6.4c-0.8,0.1-1.7,0.2-2.5,0.3c-0.2,0-0.4,0.1-0.6,0.1
+		c-0.8,0.1-1.5,0.3-2.3,0.4c-0.1,0-0.2,0-0.3,0c0,0-0.1,0-0.1,0c-13.8,3.2-24.8,14.3-27.9,28.2c0,0.1-0.1,0.2-0.1,0.4
+		c-0.5,2.5-0.8,5.1-0.8,7.7c0,1.1,0.9,2,2,2h56.5h28.1c1.1,0,2-0.9,2-2v-1.2v-60.1l4.8-4.8l9.9-9.9l25.4-25.4h26.6v19.4v14v10.3v6.7
+		v0c0,1.6,0.1,3.2,0.4,4.8c0.5,2.6,1.3,5.1,2.5,7.5c1.4,3.2,3.3,6.1,5.8,8.6l19.7,19.7l0,0l4.5,4.5c-0.5,0.6-1.1,1.3-1.6,2
+		c-0.1,0.2-0.3,0.3-0.4,0.5c-0.5,0.6-0.9,1.2-1.3,1.9c0,0.1-0.1,0.1-0.1,0.2c0,0,0,0.1-0.1,0.1c-7.5,12.1-7.4,27.6,0.2,39.7
+		c0.1,0.1,0.1,0.2,0.2,0.3c1.4,2.1,3,4.2,4.9,6.1c0.4,0.4,0.9,0.6,1.4,0.6s1-0.2,1.4-0.6l59.8-59.8c0.1-0.1,0.2-0.2,0.3-0.3
+		c0-0.1,0.1-0.1,0.1-0.2c0,0,0-0.1,0.1-0.1c0-0.1,0.1-0.2,0.1-0.3c0,0,0-0.1,0-0.1c0.1-0.3,0.1-0.5,0-0.8c0,0,0-0.1,0-0.1
+		c0-0.1,0-0.2-0.1-0.3c0,0,0-0.1-0.1-0.1c0-0.1-0.1-0.2-0.1-0.2c-0.1-0.1-0.2-0.2-0.3-0.3l-0.8-0.8l-4.5-4.5c0,0,0,0,0,0s0,0,0,0
+		l-38.1-38.1v-6.8v-14v-21.4c0.6,0,1.2,0.1,1.8,0.1c5.8,0,11.6-2.2,16-6.6l2.2-2.2l18.9-18.9l18.6-18.6c0,0,0,0,0,0l1.4-1.4
+		c0,0,0,0,0.1-0.1c4.3-4.3,6.6-10,6.6-16c0-5.7-2.1-11.1-6-15.3c-0.1-0.3-0.3-0.6-0.5-0.9l-1.9-1.9l0,0l-39.1-39.1v-3.7h26.4
+		c0.1,0,0.2,0,0.3,0c0.1,0,0.2,0,0.3,0c10.7,0,19.4-8.7,19.4-19.4s-8.7-19.4-19.4-19.4h-46.1c-3.1,0-5.7-2.5-5.7-5.7
+		s2.5-5.7,5.7-5.7h69.2c0.6,0,1.1-0.1,1.7-0.3c10.3-1.6,18-10.6,18-21C1642.3-612.1,1632.8-621.7,1621-621.7z M1599.5-541
+		c-0.1,0-0.2,0-0.3,0c-0.1,0-0.2,0-0.3,0h-29c-3.7-6.9-11-11.5-19.3-11.5h-4.5c0.1,0.1,0.1,0.2,0.2,0.2c-4.1-5-9.6-8.7-16-10.4
+		c-0.2-1.5-1-2.9-2.1-3.8c0.2,0.1,0.3,0.3,0.5,0.5c2.8-1.6,5.4-3.5,7.9-5.6c-0.2,0.2-0.4,0.4-0.6,0.5c1.2,8.6,8.5,15.3,17.5,15.3
+		h46.1c4.1,0,7.4,3.3,7.4,7.4S1603.6-541,1599.5-541z M1564.7-604v-5.7h56.4c5.1,0,9.3,4.2,9.3,9.3s-4.2,9.3-9.3,9.3h-67.7
+		c-1.2,0-2.3,0.1-3.4,0.3c0,0,0,0.1-0.1,0.1c0.2-0.4,0.4-0.9,0.5-1.3h2.2C1559.3-592,1564.7-597.4,1564.7-604z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1194.6-2621.9c0-10.6-8.6-19.3-19.3-19.3h-65.9c-2.2,0-4,1.8-4,4s1.8,4,4,4h65.9c6.2,0,11.3,5.1,11.3,11.3s-5.1,11.3-11.3,11.3
+		h-67.7c-8.6,0-15.7,7-15.7,15.7s7,15.7,15.7,15.7h46.1c5.2,0,9.4,4.2,9.4,9.4s-4.2,9.4-9.4,9.4c-0.1,0-0.2,0-0.3,0
+		c-0.1,0-0.2,0-0.3,0h-36.5c-2.2,0-4,1.8-4,4s1.8,4,4,4h36.5c0.1,0,0.2,0,0.3,0c0.1,0,0.2,0,0.3,0c9.6,0,17.4-7.8,17.4-17.4
+		s-7.8-17.4-17.4-17.4h-46.1c-4.2,0-7.7-3.4-7.7-7.7s3.4-7.7,7.7-7.7h69.2c0.5,0,0.9-0.1,1.3-0.2
+		C-1201.7-2604.2-1194.6-2612.3-1194.6-2621.9z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1284.3-2468.5h-16.5v-103.6h16.5c11,0,20,8.9,20,20v63.7C-1264.4-2477.4-1273.3-2468.5-1284.3-2468.5z"/>
+	<g>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1361.6-2541.3l-29.2-29.2l-50.7,50.7l-26.8-26.8c-8.1-8.1-21.1-8.1-29.2,0c-8.1,8.1-8.1,21.1,0,29.2l0,0l41.1,41.1c0,0,0,0,0,0
+			c3.7,3.8,8.9,6.1,14.6,6.1c5.7,0,10.9-2.3,14.6-6l0.2,0.2L-1361.6-2541.3z"/>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1456.3-2476.2c3.7,3.8,8.9,6.1,14.6,6.1c5.7,0,10.9-2.3,14.6-6l0.2,0.2l1.9-1.9c-3.4-5.5-9.4-9.2-16.3-9.2
+			c-7,0-13.2,3.8-16.5,9.5L-1456.3-2476.2C-1456.4-2476.2-1456.3-2476.2-1456.3-2476.2z"/>
+		
+			<rect x="-1491.4" y="-2526.8" transform="matrix(0.7071 -0.7071 0.7071 0.7071 1350.9954 -1778.0056)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="14"/>
+		
+			<rect x="-1420.9" y="-2538.9" transform="matrix(0.7071 -0.7071 0.7071 0.7071 1366.5629 -1737.3337)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="14" height="41.3"/>
+	</g>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1256.3-2356.6l-7.2-7.2l-19-19v-66.6c0-2.5-0.4-5-1.1-7.2v-97.5c0-16.1-13-29.1-29.1-29.1h-55.7c-16.1,0-29.1,13-29.1,29.1v93.2
+		l-47.8,47.8c-2.9,2.9-4.9,6.4-6.1,10c-1.2,2.9-1.9,6.1-1.9,9.5v36.1c-19.2,0.4-34.6,16-34.6,35.2h35.2h49.3v-25v-10.2v-26.9
+		l41.2-41.2h29.4v52.4c0,4.1,1,8,2.8,11.4c1.2,2.9,3,5.7,5.4,8l25.5,25.5c-13.3,13.8-13.1,35.7,0.5,49.4l24.9-24.9l34.9-34.9
+		L-1256.3-2356.6z"/>
+	
+		<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1487" y1="-2330" x2="-1403.2" y2="-2330"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1453.2-2357.7c-2.5,0-4.9,0.3-7.2,0.9l29.1,34.3h28.1v-1.2l-50-42.3V-2357.7z"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1426.5" cy="-2332.2" r="4.3"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1436.5-2406.1c0-4.5-1.5-8.6-4-11.9l-4.7,4.7c-2.9,2.9-4.9,6.4-6.1,10c-1.2,2.9-1.9,6.1-1.9,9.5v7.2
+		C-1443.8-2388.1-1436.5-2396.2-1436.5-2406.1z"/>
+	
+		<rect x="-1435.6" y="-2419.6" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 -702.0945 -5116.0508)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="50" height="14"/>
+	
+		<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1303.2" y1="-2285" x2="-1243.9" y2="-2344.2"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1298.9-2328.5c-1.7,1.8-3.2,3.7-4.5,5.7l44.9,3.7l19.9-19.9l-0.8-0.8l-65.3,5.4L-1298.9-2328.5z"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1262" cy="-2329.4" r="4.3"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1321.3-2374.6c-3.2-3.2-7.2-5-11.3-5.6v6.7c0,4.1,1,8,2.8,11.4c1.2,2.9,3,5.7,5.4,8l5.1,5.1
+		C-1313.7-2356.7-1314.3-2367.6-1321.3-2374.6z"/>
+	
+		<rect x="-1332.6" y="-2404.5" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="50" height="14"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1341.2-3238.2c-11.3-5.1-24.7-0.2-29.8,11.2c-23.4,51.3-67.6,52.3-69.5,52.3c0,0,0,0,0,0c-12.4,0-22.5,10.1-22.5,22.5
+		c0,12.4,10,22.5,22.4,22.5v0c0,0,0,0,0.1,0c0,0,0,0,0,0c0,0,0,0,0,0c6.5,0,75.6-2,110.5-78.7
+		C-1324.9-3219.7-1329.9-3233-1341.2-3238.2z"/>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1244.4-3107.4c-0.5,0-1,0-1.5,0c-12.4-0.8-21.8-11.5-21-23.9c1.4-21.2-3-37.3-13-47.7c-15.4-16-40.9-16-41.1-16
+			c-12.4,0.3-22.8-9.5-23.1-21.9c-0.3-12.4,9.5-22.8,21.9-23.1c4.6-0.1,45.7-0.4,74.8,29.8c19.2,20,27.8,47.5,25.5,81.9
+			C-1222.7-3116.6-1232.6-3107.4-1244.4-3107.4z"/>
+	</g>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1261.5-3051.7c-18.5-11.4-28.3-27.1-29.9-47.8c-1.3-17,3.1-31.2,3.1-31.2c8-40.9-4.6-68.8-17.8-103.2h-59.8
+		c0.7,29.9-3,58.2-10.4,85c-5.6,7-13.3,18.2-19.1,32.7c-10.9,27.2-10.6,54.8,0.6,80.7l-4.3,3.6c-9.5,8-10.8,22.1-2.9,31.7
+		c4.5,5.3,10.9,8.1,17.3,8.1c5.1,0,10.2-1.7,14.4-5.2l18.4-15.3c8.8-7.3,10.7-20,4.5-29.6c-11.9-18.2-14-36.5-6.6-56
+		c4.2-11,13.8-23.2,19.5-29.8c-1.4,8.1-2.4,18.5-1.8,29.9c1.9,31,15.2,57.1,38.9,76l-1.5,10.7c-1.8,12.3,6.8,23.7,19.1,25.5
+		c1.1,0.2,2.2,0.2,3.2,0.2c11,0,20.6-8.1,22.2-19.3l3.5-24.3C-1249.8-3038.3-1253.9-3047-1261.5-3051.7z"/>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1813-2992.2c-6.4,0-12.8-2.8-17.3-8.1c-8-9.5-6.7-23.7,2.9-31.7l4.3-3.6c-11.2-25.9-11.5-53.5-0.6-80.7
+			c9.6-23.9,24.5-39,26.2-40.7l33.6,16.1l5.4,7.9c-0.1,0.1-17.8,18.7-23.8,34.7c-7.4,19.5-5.2,37.8,6.6,56
+			c6.2,9.6,4.3,22.3-4.5,29.6l-18.4,15.3C-1802.8-2993.9-1807.9-2992.2-1813-2992.2z"/>
+	</g>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1705-2985.8c-1.1,0-2.1-0.1-3.2-0.2c-12.3-1.8-20.8-13.2-19.1-25.5l1.5-10.7c-23.6-19-37-45-38.9-76c-1.5-25.7,5.5-45.8,6.4-48
+			l42.2,15.6l0-0.1c0,0.1-4.9,14.2-3.6,31.2c1.6,20.8,11.4,36.4,29.9,47.8c7.6,4.7,11.7,13.5,10.5,22.3l-3.5,24.3
+			C-1684.4-2993.9-1694-2985.8-1705-2985.8z"/>
+	</g>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1716.5-3130h-93.9c11.2-32.4,17.1-66.9,16.2-104h59.8C-1721-3199.4-1715-3164.7-1716.5-3130z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1390.7-3266.2h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+		C-1380.7-3270.7-1385.2-3266.2-1390.7-3266.2z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1324.7-3234h-21.1c-25.6,0-46.4-20.8-46.4-46.4v-12.1c0-25.6,20.8-46.4,46.4-46.4h21.1c25.6,0,46.4,20.8,46.4,46.4v12.1
+		C-1278.3-3254.8-1299.1-3234-1324.7-3234z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1376.7-3303.8v0.4v41.3v0.4c23.5,9.9,47.1,9.9,70.6,0v-0.4v-41.3v-0.4C-1329.7-3313.7-1353.2-3313.7-1376.7-3303.8z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1276.8-3266.2h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+		C-1266.8-3270.7-1271.3-3266.2-1276.8-3266.2z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1305.5-3229.7h-59.4c-2.4,0-4.3-1.9-4.3-4.3l0,0c0-2.4,1.9-4.3,4.3-4.3h59.4c2.4,0,4.3,1.9,4.3,4.3l0,0
+		C-1301.2-3231.6-1303.1-3229.7-1305.5-3229.7z"/>
+	<path fill="none" stroke="#231F20" stroke-width="45" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-940-3139c0,0-51.9,51-12.9,110.9l-18.4,15.3"/>
+	<path fill="none" stroke="#231F20" stroke-width="45" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-894.5-3135.4c0,0-25.2,68.3,35.6,105.8l-3.5,24.3"/>
+	<path fill="none" stroke="#231F20" stroke-width="45" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-999.1-3152.2c0,0,59.9,0.9,90.1-65.5"/>
+	<path fill="none" stroke="#231F20" stroke-width="45" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-870.9-3223.1c0,0,83.2-2.3,77.2,87.7"/>
+	
+		<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1394.8" y1="-3035.6" x2="-1344.1" y2="-3033.7"/>
+	
+		<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1399.2" y1="-3032" x2="-1344.8" y2="-3023.7"/>
+	
+		<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1297.5" y1="-3022.2" x2="-1252.8" y2="-3041.8"/>
+	
+		<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1298.4" y1="-3016.5" x2="-1252.8" y2="-3032"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1396.1-2615.5h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+		C-1386.1-2620-1390.5-2615.5-1396.1-2615.5z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1330-2583.3h-21.1c-25.6,0-46.4-20.8-46.4-46.4v-12.1c0-25.6,20.8-46.4,46.4-46.4h21.1c25.6,0,46.4,20.8,46.4,46.4v12.1
+		C-1283.6-2604.1-1304.4-2583.3-1330-2583.3z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1282.2-2615.5h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+		C-1272.2-2620-1276.7-2615.5-1282.2-2615.5z"/>
+	
+		<rect x="-859.6" y="-2422.5" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="50" height="126"/>
+	
+		<rect x="-945.6" y="-2422.5" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="50" height="96.3"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1890.5" cy="-2499.8" r="20.6"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-919.7" cy="-2632.1" r="20.6"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-839" cy="-2645.3" r="20.6"/>
+	
+		<rect x="-859.6" y="-2645.3" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="92.4"/>
+	
+		<rect x="-1012.1" y="-2652.8" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="92.4" height="41.3"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-919.7" cy="-2528.5" r="20.6"/>
+	
+		<rect x="-977.9" y="-2549.2" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="58.2" height="41.3"/>
+	<g>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1922" cy="-2513.4" r="20.6"/>
+		
+			<rect x="-1922.1" y="-2521.9" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 -5008.6982 -2911.0315)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="58.2"/>
+	</g>
+	
+		<rect x="-1877.9" y="-2578.9" transform="matrix(0.7071 0.7071 -0.7071 0.7071 -2334.8569 571.4329)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="92.4"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1703.4" cy="-2619.8" r="20.6"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1795.8" cy="-2620" r="20.6"/>
+	
+		<rect x="-1795.8" y="-2640.5" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="92.4" height="41.3"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1311.7-2609.3v-0.5v-52v-0.5c-26.3-11-52.7-12.3-79-3.7c-4.3,7-6.8,15.3-6.8,24.1v12.1c0,8.8,2.5,17.1,6.8,24.1
+		C-1364.4-2597.1-1338.1-2598.3-1311.7-2609.3z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-559.1-2425.9h-55.7c-16.1,0-29.1-13-29.1-29.1v-99.3c0-16.1,13-29.1,29.1-29.1h55.7c16.1,0,29.1,13,29.1,29.1v99.3
+		C-530-2438.9-543-2425.9-559.1-2425.9z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-642.4-2615.5h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+		C-632.4-2620-636.9-2615.5-642.4-2615.5z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-576.4-2583.3h-21.1c-25.6,0-46.4-20.8-46.4-46.4v-12.1c0-25.6,20.8-46.4,46.4-46.4h21.1c25.6,0,46.4,20.8,46.4,46.4v12.1
+		C-530-2604.1-550.7-2583.3-576.4-2583.3z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-528.5-2615.5h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+		C-518.5-2620-523-2615.5-528.5-2615.5z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-557.2-2579h-59.4c-2.4,0-4.3-1.9-4.3-4.3l0,0c0-2.4,1.9-4.3,4.3-4.3h59.4c2.4,0,4.3,1.9,4.3,4.3l0,0
+		C-552.9-2580.9-554.8-2579-557.2-2579z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-691.6-2378L-691.6-2378c-9.8-9.8-9.8-25.6,0-35.4l53.7-53.7c9.8-9.8,25.6-9.8,35.4,0l0,0c9.8,9.8,9.8,25.6,0,35.4l-53.7,53.7
+		C-666-2368.2-681.8-2368.2-691.6-2378z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-554.3-2348.5L-554.3-2348.5c-13.8,0-25-11.2-25-25v-76c0-13.8,11.2-25,25-25h0c13.8,0,25,11.2,25,25v76
+		C-529.3-2359.7-540.5-2348.5-554.3-2348.5z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-674.6-2322.5L-674.6-2322.5c-13.8,0-25-11.2-25-25v-46.3c0-13.8,11.2-25,25-25l0,0c13.8,0,25,11.2,25,25v46.3
+		C-649.6-2333.7-660.7-2322.5-674.6-2322.5z"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-623.2" cy="-2555.9" r="20.6"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-688.5" cy="-2491.6" r="20.6"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-550.6" cy="-2555.9" r="20.6"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-674.6" cy="-2395" r="24.3"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-503-2321.3L-503-2321.3c-9.8,9.8-25.6,9.8-35.4,0l-32.8-32.8c-9.8-9.8-9.8-25.6,0-35.4l0,0c9.8-9.8,25.6-9.8,35.4,0l32.8,32.8
+		C-493.3-2346.9-493.3-2331.1-503-2321.3z"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-554.3" cy="-2372.6" r="24.3"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-554.3" cy="-2450.2" r="24.3"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-698.9-2322.5h-35.2l0,0c0-19.5,15.8-35.2,35.2-35.2h0V-2322.5z"/>
+	
+		<rect x="-698.9" y="-2357.7" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="49.3" height="35.2"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-522.5-2305l-24.9,24.9l0,0c-13.8-13.8-13.8-36.1,0-49.8l0,0L-522.5-2305z"/>
+	
+		<rect x="-542.2" y="-2352.6" transform="matrix(0.7071 -0.7071 0.7071 0.7071 1499.4696 -1049.8552)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="49.3" height="35.2"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-726.7" cy="-2529.7" r="20.6"/>
+	
+		<rect x="-726.8" y="-2538.2" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 -2979.6687 -3784.1265)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="58.2"/>
+	
+		<rect x="-675.9" y="-2570.7" transform="matrix(0.7071 0.7071 -0.7071 0.7071 -1976.9896 -276.0692)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="92.4"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-558-2609.3v-0.5v-52v-0.5c-26.3-11-52.7-12.3-79-3.7c-4.3,7-6.8,15.3-6.8,24.1v12.1c0,8.8,2.5,17.1,6.8,24.1
+		C-610.7-2597.1-584.4-2598.3-558-2609.3z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1747-2673.3c1,3,1.8,6.4,2.3,10.2"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="9" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1800-2696.2c0,0,29.2-7.4,45.3,9.7"/>
+	<g>
+		<g>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1324.6-2616.9c-2.2,0-4.2-1.7-4.5-3.9c-0.4-3.4-1.1-6.5-2.1-9.3c-0.8-2.4,0.5-4.9,2.8-5.7c2.4-0.8,4.9,0.5,5.7,2.8
+				c1.1,3.4,2,7.1,2.5,11.1c0.3,2.5-1.4,4.7-3.9,5C-1324.2-2616.9-1324.4-2616.9-1324.6-2616.9z"/>
+		</g>
+		<g>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1334.5-2640.2c-1.2,0-2.4-0.5-3.3-1.4c-14.2-15.1-40.7-8.5-40.9-8.5c-2.4,0.6-4.9-0.8-5.5-3.2s0.8-4.9,3.2-5.5
+				c1.3-0.3,32-7.9,49.7,11c1.7,1.8,1.6,4.7-0.2,6.4C-1332.3-2640.6-1333.4-2640.2-1334.5-2640.2z"/>
+		</g>
+	</g>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1310.9-2579h-59.4c-2.4,0-4.3-1.9-4.3-4.3l0,0c0-2.4,1.9-4.3,4.3-4.3h59.4c2.4,0,4.3,1.9,4.3,4.3l0,0
+		C-1306.6-2580.9-1308.5-2579-1310.9-2579z"/>
+	<g>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-288.2-2467.1L-288.2-2467.1c-9.8-9.8-25.6-9.8-35.4,0l-53.7,53.7c-2.9,2.9-4.9,6.4-6.1,10c-1.2,2.9-1.9,6.1-1.9,9.5v36.1
+			c-19.2,0.4-34.6,16-34.6,35.2h35.2h49.3v-25v-10.2v-26.9l47.1-47.1C-278.5-2441.5-278.5-2457.3-288.2-2467.1z"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-419.1" y1="-2330" x2="-335.3" y2="-2330"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-385.3-2357.7c-2.5,0-4.9,0.3-7.2,0.9l29.1,34.3h28.1v-1.2l-50-42.3V-2357.7z"/>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-358.6" cy="-2332.2" r="4.3"/>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-368.5-2406.1c0-4.5-1.5-8.6-4-11.9l-4.7,4.7c-2.9,2.9-4.9,6.4-6.1,10c-1.2,2.9-1.9,6.1-1.9,9.5v7.2
+			C-375.8-2388.1-368.5-2396.2-368.5-2406.1z"/>
+		
+			<rect x="-367.7" y="-2419.6" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 1121.0044 -4360.8984)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="50" height="14"/>
+	</g>
+	<g>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-239.6-2474.5L-239.6-2474.5c-13.8,0-25,11.2-25,25l0,76c0,4.1,1,8,2.8,11.4c1.2,2.9,3,5.7,5.4,8l25.5,25.5
+			c-13.3,13.8-13.1,35.7,0.5,49.4l24.9-24.9l34.9-34.9l-17.7-17.7l-7.2-7.2l-19-19l0-66.6C-214.6-2463.3-225.8-2474.5-239.6-2474.5z
+			"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-235.2" y1="-2285" x2="-176" y2="-2344.2"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-231-2328.5c-1.7,1.8-3.2,3.7-4.5,5.7l44.9,3.7l19.9-19.9l-0.8-0.8l-65.3,5.4L-231-2328.5z"/>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-194" cy="-2329.4" r="4.3"/>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-253.3-2374.6c-3.2-3.2-7.2-5-11.3-5.6l0,6.7c0,4.1,1,8,2.8,11.4c1.2,2.9,3,5.7,5.4,8l5.1,5.1
+			C-245.7-2356.7-246.3-2367.6-253.3-2374.6z"/>
+		
+			<rect x="-264.6" y="-2404.5" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="50" height="14"/>
+	</g>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-328.1-2615.5h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+		C-318.1-2620-322.6-2615.5-328.1-2615.5z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-262.1-2583.3h-21.1c-25.6,0-46.4-20.8-46.4-46.4v-12.1c0-25.6,20.8-46.4,46.4-46.4h21.1c25.6,0,46.4,20.8,46.4,46.4v12.1
+		C-215.7-2604.1-236.5-2583.3-262.1-2583.3z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-214.3-2615.5h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+		C-204.3-2620-208.7-2615.5-214.3-2615.5z"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-308.9" cy="-2555.9" r="20.6"/>
+	<g>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-415" cy="-2532" r="20.6"/>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-373.8" cy="-2490.8" r="20.6"/>
+		
+			<rect x="-415" y="-2540.5" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 -2449.0947 -4008.3396)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="58.2"/>
+	</g>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-308.2" cy="-2555.9" r="20.6"/>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-373.7" cy="-2490.7" r="20.6"/>
+	
+		<rect x="-361.6" y="-2569.5" transform="matrix(0.7071 0.7071 -0.7071 0.7071 -1884.0648 -497.9821)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="92.4"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-243.8-2609.3v-0.5v-52v-0.5c-26.3-11-52.7-12.3-79-3.7c-4.3,7-6.8,15.3-6.8,24.1v12.1c0,8.8,2.5,17.1,6.8,24.1
+		C-296.5-2597.1-270.1-2598.3-243.8-2609.3z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-256.7-2634.2c1,3,1.8,6.4,2.3,10.2"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-309.7-2657c0,0,29.2-7.4,45.3,9.7"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-244.8-2425.9h-55.7c-16.1,0-29.1-13-29.1-29.1v-99.3c0-16.1,13-29.1,29.1-29.1h55.7c16.1,0,29.1,13,29.1,29.1v99.3
+		C-215.7-2438.9-228.7-2425.9-244.8-2425.9z"/>
+	<g>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-211.8" cy="-2449.2" r="20.6"/>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-170.7" cy="-2490.3" r="20.6"/>
+		
+			<rect x="-211.9" y="-2498.9" transform="matrix(0.7071 0.7071 -0.7071 0.7071 -1802.4082 -588.1622)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="58.2"/>
+	</g>
+	
+		<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-170.6" cy="-2490.4" r="20.6"/>
+	
+		<rect x="-223.7" y="-2569.5" transform="matrix(0.7071 -0.7071 0.7071 0.7071 1724.7283 -882.6544)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="92.4"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-242.9-2579h-59.4c-2.4,0-4.3-1.9-4.3-4.3l0,0c0-2.4,1.9-4.3,4.3-4.3h59.4c2.4,0,4.3,1.9,4.3,4.3l0,0
+		C-238.6-2580.9-240.6-2579-242.9-2579z"/>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1334.9-2471.5h-43.5c-4.2,0-7.6-3.4-7.6-7.6v-72.5c0-4.2,3.4-7.6,7.6-7.6h43.5c4.2,0,7.6,3.4,7.6,7.6v72.5
+			C-1327.3-2474.9-1330.7-2471.5-1334.9-2471.5z"/>
+		
+			<circle fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1338.1" cy="-2548.2" r="5"/>
+		
+			<circle fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1338.1" cy="-2526.3" r="5"/>
+		
+			<circle fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1338.1" cy="-2504.4" r="5"/>
+		
+			<circle fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1338.1" cy="-2482.5" r="5"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1354.4-2543.1h-20.5c-2.8,0-5-2.3-5-5l0,0c0-2.8,2.3-5,5-5h20.5c2.8,0,5,2.3,5,5l0,0
+			C-1349.3-2545.4-1351.6-2543.1-1354.4-2543.1z"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1354.4-2521.2h-20.5c-2.8,0-5-2.3-5-5l0,0c0-2.8,2.3-5,5-5h20.5c2.8,0,5,2.3,5,5l0,0
+			C-1349.3-2523.5-1351.6-2521.2-1354.4-2521.2z"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1354.4-2499.3h-20.5c-2.8,0-5-2.3-5-5v0c0-2.8,2.3-5,5-5h20.5c2.8,0,5,2.3,5,5v0C-1349.3-2501.6-1351.6-2499.3-1354.4-2499.3z"
+			/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1354.4-2477.4h-20.5c-2.8,0-5-2.3-5-5l0,0c0-2.8,2.3-5,5-5h20.5c2.8,0,5,2.3,5,5l0,0
+			C-1349.3-2479.7-1351.6-2477.4-1354.4-2477.4z"/>
+	</g>
+	
+		<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1397.5" y1="-2461.1" x2="-1283.6" y2="-2461.1"/>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1317.3-2540.5l50.7,50.7l-26.8,26.8c-8.1,8.1-8.1,21.1,0,29.2s21.1,8.1,29.2,0c0,0,0,0,0,0l41.1-41.1c0,0,0,0,0,0
+			c3.8-3.7,6.1-8.9,6.1-14.6c0-5.7-2.3-10.9-6-14.6l0.2-0.2l-65.3-65.3"/>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1223-2474.9c3.8-3.7,6.1-8.9,6.1-14.6c0-5.7-2.3-10.9-6-14.6l0.2-0.2l-1.9-1.9c-5.5,3.4-9.2,9.4-9.2,16.3c0,7,3.8,13.2,9.5,16.5
+			L-1223-2474.9C-1223-2474.9-1223-2474.9-1223-2474.9z"/>
+		
+			<rect x="-1287.2" y="-2467.5" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 -422.3272 -5095.9995)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="41.3" height="14"/>
+		
+			<rect x="-1272" y="-2538.1" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 -379.4751 -5192.002)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="14" height="41.3"/>
+		
+			<rect x="-1304.9" y="-2570.9" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 -412.321 -5271.2988)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="14" height="41.3"/>
+	</g>
+	<g>
+		
+			<line fill="none" stroke="#231F20" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1831" y1="-2430.2" x2="-1794.5" y2="-2430.2"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1838.3" y1="-2510.8" x2="-1772.4" y2="-2510.8"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1840" y1="-2480.3" x2="-1770.8" y2="-2480.3"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-1840" y1="-2457" x2="-1793.9" y2="-2457"/>
+		<path fill="none" stroke="#231F20" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1772.4-2510.8c8.4,0,15.3,6.8,15.3,15.3c0,8.4-6.8,15.3-15.3,15.3"/>
+		<path fill="none" stroke="#231F20" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1840-2457c-6.4,0-11.7-5.2-11.7-11.7s5.2-11.7,11.7-11.7"/>
+		<path fill="none" stroke="#231F20" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1793.9-2457c7.4,0,13.4,6,13.4,13.4c0,7.4-6,13.4-13.4,13.4"/>
+	</g>
+	
+		<line fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1362" y1="-2425.9" x2="-1379.9" y2="-2461.1"/>
+	
+		<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1332.6" y1="-2425.9" x2="-1332.6" y2="-2460.5"/>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-629.7-1813.1c0-10.6-8.6-19.3-19.3-19.3h-65.9c-2.2,0-4,1.8-4,4s1.8,4,4,4h65.9c6.2,0,11.3,5.1,11.3,11.3s-5.1,11.3-11.3,11.3
+			h-67.7c-8.6,0-15.7,7-15.7,15.7s7,15.7,15.7,15.7h46.1c5.2,0,9.4,4.2,9.4,9.4s-4.2,9.4-9.4,9.4c-0.1,0-0.2,0-0.3,0
+			c-0.1,0-0.2,0-0.3,0h-36.5c-2.2,0-4,1.8-4,4s1.8,4,4,4h36.5c0.1,0,0.2,0,0.3,0c0.1,0,0.2,0,0.3,0c9.6,0,17.4-7.8,17.4-17.4
+			s-7.8-17.4-17.4-17.4h-46.1c-4.2,0-7.7-3.4-7.7-7.7s3.4-7.7,7.7-7.7h69.2c0.5,0,0.9-0.1,1.3-0.2
+			C-636.9-1795.4-629.7-1803.4-629.7-1813.1z"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-719.5-1659.6h-16.5v-103.6h16.5c11,0,20,8.9,20,20v63.7C-699.5-1668.6-708.4-1659.6-719.5-1659.6z"/>
+		<g>
+			<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-796.7-1732.5l-29.2-29.2l-50.7,50.7l-26.8-26.8c-8.1-8.1-21.1-8.1-29.2,0c-8.1,8.1-8.1,21.1,0,29.2l0,0l41.1,41.1c0,0,0,0,0,0
+				c3.7,3.8,8.9,6.1,14.6,6.1c5.7,0,10.9-2.3,14.6-6l0.2,0.2L-796.7-1732.5z"/>
+			<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-891.5-1667.3c3.7,3.8,8.9,6.1,14.6,6.1c5.7,0,10.9-2.3,14.6-6l0.2,0.2l1.9-1.9c-3.4-5.5-9.4-9.2-16.3-9.2
+				c-7,0-13.2,3.8-16.5,9.5L-891.5-1667.3C-891.5-1667.4-891.5-1667.3-891.5-1667.3z"/>
+			
+				<polygon fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+				-896.2,-1730.5 -932.6,-1708.5 -909.6,-1685.4 -886.3,-1720.6 			"/>
+			
+				<rect x="-856" y="-1730" transform="matrix(0.7071 -0.7071 0.7071 0.7071 960.0548 -1100.9971)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="14" height="41.3"/>
+		</g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-691.4-1547.7l-7.2-7.2l-19-19l0-66.6c0-2.5-0.4-5-1.1-7.2v-97.5c0-16.1-13-29.1-29.1-29.1h-55.7c-16.1,0-29.1,13-29.1,29.1v93.2
+			l-47.8,47.8c-2.9,2.9-4.9,6.4-6.1,10c-1.2,2.9-1.9,6.1-1.9,9.5v36.1c-19.2,0.4-34.6,16-34.6,35.2h35.2h49.3v-25v-10.2v-26.9
+			l41.2-41.2h29.4l0,52.4c0,4.1,1,8,2.8,11.4c1.2,2.9,3,5.7,5.4,8l25.5,25.5c-13.3,13.8-13.1,35.7,0.5,49.4l24.9-24.9l34.9-34.9
+			L-691.4-1547.7z"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-922.1" y1="-1521.1" x2="-838.4" y2="-1521.1"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-888.4-1548.8c-2.5,0-4.9,0.3-7.2,0.9l29.1,34.3h28.1v-1.2l-50-42.3V-1548.8z"/>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-861.6" cy="-1523.4" r="4.3"/>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-871.6-1597.3c0-4.5-1.5-8.6-4-11.9l-4.7,4.7c-2.9,2.9-4.9,6.4-6.1,10c-1.2,2.9-1.9,6.1-1.9,9.5v7.2
+			C-878.9-1579.2-871.6-1587.4-871.6-1597.3z"/>
+		
+			<rect x="-870.7" y="-1610.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 -309.7526 -3335.8035)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="50" height="14"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-738.3" y1="-1476.1" x2="-679.1" y2="-1535.4"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-734-1519.6c-1.7,1.8-3.2,3.7-4.5,5.7l44.9,3.7l19.9-19.9l-0.8-0.8l-65.3,5.4L-734-1519.6z"/>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-697.1" cy="-1520.5" r="4.3"/>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-756.4-1565.7c-3.2-3.2-7.2-5-11.3-5.6v6.7c0,4.1,1,8,2.8,11.4c1.2,2.9,3,5.7,5.4,8l5.1,5.1
+			C-748.8-1547.8-749.4-1558.7-756.4-1565.7z"/>
+		
+			<rect x="-767.7" y="-1595.6" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="50" height="14"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-831.2-1806.7h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+			C-821.2-1811.1-825.7-1806.7-831.2-1806.7z"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-765.2-1774.5h-21.1c-25.6,0-46.4-20.8-46.4-46.4v-12.1c0-25.6,20.8-46.4,46.4-46.4h21.1c25.6,0,46.4,20.8,46.4,46.4v12.1
+			C-718.8-1795.3-739.5-1774.5-765.2-1774.5z"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-717.3-1806.7h-2.9c-5.5,0-10-4.5-10-10v-13.2c0-5.5,4.5-10,10-10h2.9c5.5,0,10,4.5,10,10v13.2
+			C-707.3-1811.1-711.8-1806.7-717.3-1806.7z"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-746.9-1800.5v-0.5v-52v-0.5c-26.3-11-52.7-12.3-79-3.7c-4.3,7-6.8,15.3-6.8,24.1v12.1c0,8.8,2.5,17.1,6.8,24.1
+			C-799.5-1788.2-773.2-1789.4-746.9-1800.5z"/>
+		<g>
+			<g>
+				
+					<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+					M-759.7-1808c-2.2,0-4.2-1.7-4.5-3.9c-0.4-3.4-1.1-6.5-2.1-9.3c-0.8-2.4,0.5-4.9,2.8-5.7c2.4-0.8,4.9,0.5,5.7,2.8
+					c1.1,3.4,2,7.1,2.5,11.1c0.3,2.5-1.4,4.7-3.9,5C-759.4-1808-759.6-1808-759.7-1808z"/>
+			</g>
+			<g>
+				
+					<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+					M-769.7-1831.3c-1.2,0-2.4-0.5-3.3-1.4c-14.2-15.1-40.7-8.5-40.9-8.5c-2.4,0.6-4.9-0.8-5.5-3.2s0.8-4.9,3.2-5.5
+					c1.3-0.3,32-7.9,49.7,11c1.7,1.8,1.6,4.7-0.2,6.4C-767.4-1831.7-768.6-1831.3-769.7-1831.3z"/>
+			</g>
+		</g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-746-1770.1h-59.4c-2.4,0-4.3-1.9-4.3-4.3l0,0c0-2.4,1.9-4.3,4.3-4.3h59.4c2.4,0,4.3,1.9,4.3,4.3l0,0
+			C-741.7-1772.1-743.6-1770.1-746-1770.1z"/>
+		<g>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-770.1-1662.6h-43.5c-4.2,0-7.6-3.4-7.6-7.6v-72.5c0-4.2,3.4-7.6,7.6-7.6h43.5c4.2,0,7.6,3.4,7.6,7.6v72.5
+				C-762.4-1666.1-765.8-1662.6-770.1-1662.6z"/>
+			
+				<circle fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-773.2" cy="-1739.3" r="5"/>
+			
+				<circle fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-773.2" cy="-1717.4" r="5"/>
+			
+				<circle fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-773.2" cy="-1695.5" r="5"/>
+			
+				<circle fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-773.2" cy="-1673.6" r="5"/>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-789.5-1734.3H-810c-2.8,0-5-2.3-5-5l0,0c0-2.8,2.3-5,5-5h20.5c2.8,0,5,2.3,5,5l0,0C-784.5-1736.5-786.7-1734.3-789.5-1734.3z"
+				/>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-789.5-1712.4H-810c-2.8,0-5-2.3-5-5l0,0c0-2.8,2.3-5,5-5h20.5c2.8,0,5,2.3,5,5l0,0C-784.5-1714.6-786.7-1712.4-789.5-1712.4z"
+				/>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-789.5-1690.5H-810c-2.8,0-5-2.3-5-5l0,0c0-2.8,2.3-5,5-5h20.5c2.8,0,5,2.3,5,5l0,0C-784.5-1692.7-786.7-1690.5-789.5-1690.5z"
+				/>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-789.5-1668.6H-810c-2.8,0-5-2.3-5-5l0,0c0-2.8,2.3-5,5-5h20.5c2.8,0,5,2.3,5,5l0,0C-784.5-1670.8-786.7-1668.6-789.5-1668.6z"
+				/>
+		</g>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="-832.6" y1="-1652.2" x2="-718.8" y2="-1652.2"/>
+		<g>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-752.4-1731.6l50.7,50.7l-26.8,26.8c-8.1,8.1-8.1,21.1,0,29.2s21.1,8.1,29.2,0c0,0,0,0,0,0l41.1-41.1c0,0,0,0,0,0
+				c3.8-3.7,6.1-8.9,6.1-14.6c0-5.7-2.3-10.9-6-14.6l0.2-0.2l-65.3-65.3"/>
+			<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-658.1-1666.1c3.8-3.7,6.1-8.9,6.1-14.6c0-5.7-2.3-10.9-6-14.6l0.2-0.2l-1.9-1.9c-5.5,3.4-9.2,9.4-9.2,16.3
+				c0,7,3.8,13.2,9.5,16.5L-658.1-1666.1C-658.1-1666-658.1-1666.1-658.1-1666.1z"/>
+			
+				<rect x="-707.2" y="-1729.2" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 12.8668 -3411.7546)" fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="14" height="41.3"/>
+			
+				<rect x="-707.8" y="-1668.2" transform="matrix(0.7071 -0.7071 0.7071 0.7071 971.8933 -974.9199)" fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="33.7" height="15.2"/>
+			
+				<polygon fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+				-721.3,-1661.3 -697.1,-1627.1 -678.2,-1646 -711.4,-1671.2 			"/>
+		</g>
+		
+			<line fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-797.2" y1="-1617" x2="-815.1" y2="-1652.2"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-767.7" y1="-1617" x2="-767.7" y2="-1651.7"/>
+		
+			<circle fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-913.3" cy="-1705.1" r="4.8"/>
+	</g>
+	<g>
+		<g>
+			
+				<rect x="-1170.3" y="-1962" transform="matrix(0.7071 -0.7071 0.7071 0.7071 1034.0162 -1285.4442)" fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="271.4" height="142.2"/>
+			
+				<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1116.8" y1="-1909" x2="-1015.8" y2="-1808.1"/>
+			
+				<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1052.8" y1="-1973" x2="-951.9" y2="-1872"/>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1154.7-1770.2l-0.6-0.6c-1.4-1.4-1.4-3.7,0-5.1l215.3-215.3c1.4-1.4,3.7-1.4,5.1,0l0.6,0.6c1.4,1.4,1.4,3.7,0,5.1l-215.3,215.3
+				C-1151-1768.8-1153.3-1768.8-1154.7-1770.2z"/>
+		</g>
+		<g>
+			
+				<rect x="-1486.5" y="-1644.8" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 -3418.679 -1731.3024)" fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="271.4" height="142.2"/>
+			
+				<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1268.7" y1="-1555.5" x2="-1369.6" y2="-1656.5"/>
+			
+				<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1332.6" y1="-1491.6" x2="-1433.6" y2="-1592.5"/>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1230.7-1694.4l0.6,0.6c1.4,1.4,1.4,3.7,0,5.1l-215.3,215.3c-1.4,1.4-3.7,1.4-5.1,0l-0.6-0.6c-1.4-1.4-1.4-3.7,0-5.1
+				l215.3-215.3C-1234.4-1695.8-1232.1-1695.8-1230.7-1694.4z"/>
+		</g>
+		<g>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1046.3-1585.5L-1046.3-1585.5c-1.6,1.6-4.1,1.6-5.7,0l-50.3-50.3c-1.6-1.6-1.6-4.1,0-5.7l0,0c1.6-1.6,4.1-1.6,5.7,0l50.3,50.3
+				C-1044.7-1589.6-1044.7-1587-1046.3-1585.5z"/>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1103.1-1561.4L-1103.1-1561.4c-2.2,0-4-1.8-4-4v-71.1c0-2.2,1.8-4,4-4l0,0c2.2,0,4,1.8,4,4v71.1
+				C-1099.1-1563.2-1100.9-1561.4-1103.1-1561.4z"/>
+			
+				<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1022.3-1642.3L-1022.3-1642.3c0-2.2-1.8-4-4-4h-71.1c-2.2,0-4,1.8-4,4l0,0c0,2.2,1.8,4,4,4h71.1
+				C-1024.1-1638.3-1022.3-1640.1-1022.3-1642.3z"/>
+		</g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1345.8-1791.4l194.8,194.8l0,0c9.6,9.6,38.3-3.6,64.2-29.4c25.8-25.8,39-54.6,29.4-64.2l0,0l-194.8-194.8L-1345.8-1791.4z"/>
+		
+			<ellipse transform="matrix(0.7071 -0.7071 0.7071 0.7071 919.3039 -1456.9327)" fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1299" cy="-1838.2" rx="66.2" ry="24.6"/>
+		<g>
+			<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1177.7-1810.4c9.6,9.6-3.6,38.3-29.4,64.2s-54.6,39-64.2,29.4"/>
+			<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1132-1764.7c9.6,9.6-3.6,38.3-29.4,64.2s-54.6,39-64.2,29.4"/>
+		</g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1296-1835.1L-1296-1835.1c-1.6,1.6-4.1,1.6-5.7,0l-50.3-50.3c-1.6-1.6-1.6-4.1,0-5.7l0,0c1.6-1.6,4.1-1.6,5.7,0l50.3,50.3
+			C-1294.4-1839.3-1294.4-1836.7-1296-1835.1z"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1301.3-1962.1L-1301.3-1962.1L-1301.3-1962.1c-12.5-12.5-49.8,4.6-83.4,38.2c-33.6,33.6-50.7,70.9-38.2,83.4l0,0l0,0l0,0l0,0
+			c0,0,34.4,34.4,74.6,9.7l0,0c10.1-5.6,21.3-14.1,31.9-24.8c10.7-10.7,19.2-21.8,24.8-31.9l0,0
+			C-1266.9-1927.6-1301.3-1962.1-1301.3-1962.1L-1301.3-1962.1L-1301.3-1962.1z"/>
+		
+			<ellipse transform="matrix(0.7071 -0.7071 0.7071 0.7071 945.4334 -1520.0146)" fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1362.1" cy="-1901.2" rx="86" ry="31.9"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1355.6-1894.7L-1355.6-1894.7c-1.6,1.6-4.1,1.6-5.7,0l-50.3-50.3c-1.6-1.6-1.6-4.1,0-5.7l0,0c1.6-1.6,4.1-1.6,5.7,0l50.3,50.3
+			C-1354-1898.9-1354-1896.3-1355.6-1894.7z"/>
+	</g>
+	<g>
+		
+			<rect x="-2061.7" y="-1628.1" fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="294.9" height="154.5"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1963.4" y1="-1627.9" x2="-1963.4" y2="-1472.7"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1865.1" y1="-1627.9" x2="-1865.1" y2="-1472.7"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-2099.3-1550.4v-0.9c0-2.2,1.8-3.9,3.9-3.9h330.8c2.2,0,3.9,1.8,3.9,3.9v0.9c0,2.2-1.8,3.9-3.9,3.9h-330.8
+			C-2097.5-1546.4-2099.3-1548.2-2099.3-1550.4z"/>
+	</g>
+	<g>
+		
+			<rect x="-2548.4" y="-1627.3" fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="294.9" height="154.5"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-2351.8" y1="-1472.9" x2="-2351.8" y2="-1628.1"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-2450.1" y1="-1472.9" x2="-2450.1" y2="-1628.1"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-2215.9-1550.4v0.9c0,2.2-1.8,3.9-3.9,3.9h-330.8c-2.2,0-3.9-1.8-3.9-3.9v-0.9c0-2.2,1.8-3.9,3.9-3.9h330.8
+			C-2217.7-1554.4-2215.9-1552.6-2215.9-1550.4z"/>
+	</g>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-2157.9-1325.1L-2157.9-1325.1c-2.4,0-4.4-2-4.4-4.4v-77.3c0-2.4,2-4.4,4.4-4.4l0,0c2.4,0,4.4,2,4.4,4.4v77.3
+			C-2153.6-1327-2155.5-1325.1-2157.9-1325.1z"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-2220.1-1350.3L-2220.1-1350.3c-1.7-1.7-1.7-4.5,0-6.2l54.6-54.6c1.7-1.7,4.5-1.7,6.2,0v0c1.7,1.7,1.7,4.5,0,6.2l-54.6,54.6
+			C-2215.6-1348.6-2218.3-1348.6-2220.1-1350.3z"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-2095.8-1350.3L-2095.8-1350.3c1.7-1.7,1.7-4.5,0-6.2l-54.6-54.6c-1.7-1.7-4.5-1.7-6.2,0v0c-1.7,1.7-1.7,4.5,0,6.2l54.6,54.6
+			C-2100.3-1348.6-2097.5-1348.6-2095.8-1350.3z"/>
+	</g>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-2229.8-1713.4v299.4l0,0c0,14.7,32.2,26.7,71.9,26.7s71.9-12,71.9-26.7l0,0v-299.4H-2229.8z"/>
+	
+		<ellipse fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-2157.9" cy="-1713.4" rx="71.9" ry="26.7"/>
+	<g>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-2086-1598.8c0,14.7-32.2,26.7-71.9,26.7s-71.9-12-71.9-26.7"/>
+		<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-2086-1528.7c0,14.7-32.2,26.7-71.9,26.7s-71.9-12-71.9-26.7"/>
+	</g>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-2157.9-1708.8L-2157.9-1708.8c-2.4,0-4.4-2-4.4-4.4v-77.3c0-2.4,2-4.4,4.4-4.4l0,0c2.4,0,4.4,2,4.4,4.4v77.3
+		C-2153.6-1710.7-2155.5-1708.8-2157.9-1708.8z"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-2064.5-1810.4L-2064.5-1810.4L-2064.5-1810.4c0-19.2-41.8-34.7-93.5-34.7s-93.5,15.5-93.5,34.7l0,0l0,0l0,0l0,0
+		c0,0,0,52.9,49.9,64.8l0,0c12.1,3.4,27.2,5.5,43.6,5.5s31.5-2,43.6-5.5l0,0C-2064.5-1757.5-2064.5-1810.4-2064.5-1810.4
+		L-2064.5-1810.4L-2064.5-1810.4z"/>
+	
+		<ellipse fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-2157.9" cy="-1810.4" rx="93.5" ry="34.7"/>
+	
+		<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-2157.9-1800.4L-2157.9-1800.4c-2.4,0-4.4-2-4.4-4.4v-77.3c0-2.4,2-4.4,4.4-4.4l0,0c2.4,0,4.4,2,4.4,4.4v77.3
+		C-2153.6-1802.3-2155.5-1800.4-2157.9-1800.4z"/>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-924.5-1803.1c5.6-5.6,6.8-13.9,3.7-20.7l-9.7,9.7l-8.8-0.4l-0.4-8.8l9.7-9.7c-6.8-3.1-15.1-1.9-20.7,3.7
+			c-4.8,4.8-6.4,11.5-4.8,17.6c0.5,2.2-0.2,4.4-1.8,6l-36.4,36.4c-2.5,2.5-2.8,6.7-0.3,9.2c2.5,2.7,6.7,2.7,9.3,0.1l36.6-36.6
+			c1.6-1.6,3.9-2.3,6-1.8C-936-1796.8-929.3-1798.4-924.5-1803.1z"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-939.3" y1="-1814.6" x2="-952.4" y2="-1827.6"/>
+	</g>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-242.4-1674.6c0-7.9-5-14.7-12-17.3v13.7l-6.5,6l-6.5-6v-13.7c-7,2.6-12,9.4-12,17.3c0,6.7,3.6,12.6,9,15.9c1.9,1.1,3,3.3,3,5.5
+			v51.4c0,3.6,2.7,6.7,6.3,6.8c3.7,0.1,6.7-2.8,6.7-6.5v-51.7c0-2.2,1.1-4.4,3-5.5C-246-1662-242.4-1667.9-242.4-1674.6z"/>
+		
+			<line fill="none" stroke="#231F20" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-260.9" y1="-1672.3" x2="-279.4" y2="-1672.3"/>
+	</g>
+	<g>
+		
+			<polygon fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+			-197.1,-1689.3 -200.3,-1697.6 -206.7,-1697.6 -209.9,-1689.3 -206.7,-1681 -206.7,-1681 -206.7,-1647.4 -200.3,-1647.4 
+			-200.3,-1681 -200.3,-1681 		"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-203.5-1595.1L-203.5-1595.1c-3.6,0-6.6-3-6.6-6.6v-50.7h13.2v50.7C-196.9-1598-199.9-1595.1-203.5-1595.1z"/>
+	</g>
+	<g>
+		
+			<polygon fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+			-988.2,-1691.2 -996.3,-1694.8 -1000.8,-1690.3 -997.2,-1682.2 -989.1,-1678.6 -989.1,-1678.6 -965.3,-1654.9 -960.9,-1659.3 
+			-984.6,-1683.1 -984.6,-1683.1 		"/>
+		
+			<path fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-926.1-1620.1L-926.1-1620.1c-2.6,2.6-6.8,2.6-9.3,0l-35.9-35.9l9.3-9.3l35.9,35.9C-923.5-1626.9-923.5-1622.7-926.1-1620.1z"/>
+	</g>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1190.7-1995.8c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-1190.1-1996.8-1190.1-1996-1190.7-1995.8z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-799.9-1956.1c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-799.3-1957.1-799.3-1956.3-799.9-1956.1z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-614.2-1937.3c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-613.6-1938.2-613.6-1937.4-614.2-1937.3z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-549.1-1645.7c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-548.5-1646.7-548.5-1645.9-549.1-1645.7z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-670.5-1442c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-669.9-1443-669.9-1442.1-670.5-1442z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-997.4-1501.3c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-996.8-1502.3-996.8-1501.5-997.4-1501.3z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1227-1432.6c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-1226.4-1433.5-1226.4-1432.7-1227-1432.6z"/>
+	<path fill="none" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1424.6-1728.2c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-1424-1729.2-1424-1728.4-1424.6-1728.2z"/>
+	
+		<circle fill="#FFFFFF" stroke="#231F20" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-680.8" cy="-1698.1" r="6"/>
+	<g>
+		<path fill="#FF5C00" d="M-768.2-608c0.9,2.7,1.6,5.7,2,8.9c0.4,3.2,3.2,5.7,6.4,5.7c0.3,0,0.5,0,0.8-0.1c1.7-0.2,3.3-1.1,4.3-2.5
+			c1.1-1.4,1.5-3.1,1.3-4.8c-0.5-4.1-1.4-8-2.6-11.5c-0.9-2.6-3.4-4.4-6.2-4.4c-0.7,0-1.4,0.1-2.1,0.3
+			C-767.5-615.1-769.3-611.4-768.2-608z M-762.8-612.4c0.3-0.1,0.5-0.1,0.8-0.1c1.1,0,2,0.7,2.4,1.7c1.1,3.3,1.9,6.9,2.4,10.7
+			c0.1,0.7-0.1,1.3-0.5,1.8c-0.4,0.5-1,0.9-1.7,0.9c-1.4,0.2-2.6-0.8-2.8-2.2c-0.4-3.5-1.2-6.8-2.2-9.7
+			C-764.8-610.6-764.1-612-762.8-612.4z"/>
+		<path fill="#FF5C00" d="M-815-626.4c0.5,0,1.1-0.1,1.6-0.2c0.2-0.1,5.8-1.4,13.1-1.4c7.8,0,18.7,1.6,25.9,9.3c1.2,1.3,3,2,4.7,2
+			c1.7,0,3.2-0.6,4.4-1.8c1.3-1.2,2-2.8,2-4.5c0.1-1.7-0.6-3.4-1.8-4.7c-10.4-11.1-25-13.4-35.4-13.4c-8.9,0-15.5,1.6-16.3,1.8
+			c-1.7,0.4-3.1,1.5-4,3c-0.9,1.5-1.1,3.2-0.7,4.9C-820.6-628.4-818-626.4-815-626.4z M-817.1-634.2c0.3-0.6,0.9-1,1.5-1.1
+			c0.3-0.1,6.7-1.7,15.3-1.7c9.6,0,23.1,2.1,32.5,12.2c0.5,0.5,0.7,1.1,0.7,1.8c0,0.7-0.3,1.3-0.8,1.7c-1,0.9-2.6,0.9-3.5-0.1
+			c-8.2-8.7-20.2-10.6-28.8-10.6c-7.8,0-13.8,1.5-14.1,1.5c-1.3,0.3-2.7-0.5-3-1.8C-817.6-632.9-817.5-633.6-817.1-634.2z"/>
+		<path fill="#FF5C00" d="M-770.1-539.8h-43.5c-5.3,0-9.6,4.3-9.6,9.6v72.5c0,5.3,4.3,9.6,9.6,9.6h43.5c5.3,0,9.6-4.3,9.6-9.6v-72.5
+			C-760.4-535.5-764.7-539.8-770.1-539.8z M-764.4-457.6c0,3.1-2.5,5.6-5.6,5.6h-43.5c-3.1,0-5.6-2.5-5.6-5.6v-72.5
+			c0-3.1,2.5-5.6,5.6-5.6h43.5c3.1,0,5.6,2.5,5.6,5.6V-457.6z"/>
+		<path fill="#FF5C00" d="M-773.2-533.7c-3.9,0-7,3.2-7,7s3.2,7,7,7c3.9,0,7-3.2,7-7S-769.3-533.7-773.2-533.7z M-773.2-523.6
+			c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S-771.5-523.6-773.2-523.6z"/>
+		<path fill="#FF5C00" d="M-773.2-511.8c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7c3.9,0,7-3.2,7-7C-766.2-508.6-769.3-511.8-773.2-511.8z
+			 M-773.2-501.7c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S-771.5-501.7-773.2-501.7z"/>
+		<path fill="#FF5C00" d="M-773.2-489.9c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7c3.9,0,7-3.2,7-7C-766.2-486.7-769.3-489.9-773.2-489.9z
+			 M-773.2-479.8c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S-771.5-479.8-773.2-479.8z"/>
+		<path fill="#FF5C00" d="M-773.2-468c-3.9,0-7,3.2-7,7s3.2,7,7,7c3.9,0,7-3.2,7-7S-769.3-468-773.2-468z M-773.2-457.9
+			c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S-771.5-457.9-773.2-457.9z"/>
+		<path fill="#FF5C00" d="M-789.5-533.7H-810c-3.9,0-7,3.2-7,7s3.2,7,7,7h20.5c3.9,0,7-3.2,7-7S-785.6-533.7-789.5-533.7z
+			 M-789.5-523.6H-810c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3S-787.8-523.6-789.5-523.6z"/>
+		<path fill="#FF5C00" d="M-789.5-511.8H-810c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7h20.5c3.9,0,7-3.2,7-7
+			C-782.5-508.6-785.6-511.8-789.5-511.8z M-789.5-501.7H-810c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3
+			S-787.8-501.7-789.5-501.7z"/>
+		<path fill="#FF5C00" d="M-789.5-489.9H-810c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7h20.5c3.9,0,7-3.2,7-7
+			C-782.5-486.7-785.6-489.9-789.5-489.9z M-789.5-479.8H-810c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3
+			S-787.8-479.8-789.5-479.8z"/>
+		<path fill="#FF5C00" d="M-789.5-468H-810c-3.9,0-7,3.2-7,7s3.2,7,7,7h20.5c3.9,0,7-3.2,7-7S-785.6-468-789.5-468z M-789.5-457.9
+			H-810c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3S-787.8-457.9-789.5-457.9z"/>
+		<path fill="#FF5C00" d="M-649-621.7h-57.3c-1.8-4.4-6.1-7.5-11.1-7.5h-0.3c-4.2-22.5-23.9-39.6-47.6-39.6h-21.1
+			c-23.7,0-43.4,17.1-47.6,39.6h-0.3c-6.6,0-12,5.4-12,12v13.2c0,6.6,5.4,12,12,12h2.2c3.9,11,11.8,20.2,21.8,25.9
+			c0.1-0.2,0.3-0.3,0.5-0.5c-1.1,1-1.9,2.3-2.1,3.8c-8.9,2.4-16.2,8.6-20,16.8c0-0.1,0.1-0.1,0.1-0.2l-45.1,45.1l-8.2-8.2l-9.9-9.9
+			l-7.2-7.2c-4.3-4.3-10-6.6-16-6.6c0,0,0,0,0,0c-6,0-11.7,2.4-16,6.6c-8.8,8.8-8.8,23.2,0,32l23.1,23.1l16.6,16.6c0,0,0,0,0,0
+			l1.4,1.4c0,0,0,0,0,0c0,0,0,0,0.1,0.1c2.8,2.8,6.2,4.8,10,5.8c0.5,0.1,1.1,0.3,1.6,0.4c1.5,0.3,2.9,0.4,4.5,0.4
+			c5.7,0,11.1-2.1,15.3-6c0.3-0.1,0.6-0.3,0.9-0.5l1.9-1.9c0,0,0,0,0,0l24.1-24.1v38.7l-25.2,25.2l-9.9,9.9l-7.3,7.3c0,0,0,0,0,0
+			l-4.7,4.7c-3,3-5.3,6.7-6.6,10.8c-1.3,3.2-2,6.7-2,10.2v7.2v20.7v6.4c-0.8,0.1-1.7,0.2-2.5,0.3c-0.2,0-0.4,0.1-0.6,0.1
+			c-0.8,0.1-1.5,0.3-2.3,0.4c-0.1,0-0.2,0-0.3,0c0,0-0.1,0-0.1,0c-13.8,3.2-24.8,14.3-27.9,28.2c0,0.1-0.1,0.2-0.1,0.4
+			c-0.5,2.5-0.8,5.1-0.8,7.7c0,1.1,0.9,2,2,2h56.5h28.1c1.1,0,2-0.9,2-2v-1.2v-60.1l4.8-4.8l9.9-9.9l25.4-25.4h26.6v19.4v14v10.3
+			v6.7v0c0,1.6,0.1,3.2,0.4,4.8c0.5,2.6,1.3,5.1,2.5,7.5c1.4,3.2,3.3,6.1,5.8,8.6l19.7,19.7c0,0,0,0,0,0l4.5,4.5
+			c-0.5,0.6-1.1,1.3-1.6,2c-0.1,0.2-0.3,0.3-0.4,0.5c-0.5,0.6-0.9,1.2-1.3,1.9c0,0.1-0.1,0.1-0.1,0.2c0,0,0,0.1-0.1,0.1
+			c-7.5,12.1-7.4,27.6,0.2,39.7c0.1,0.1,0.1,0.2,0.2,0.3c1.4,2.1,3,4.2,4.9,6.1c0.4,0.4,0.9,0.6,1.4,0.6s1-0.2,1.4-0.6l59.8-59.8
+			c0.1-0.1,0.2-0.2,0.3-0.3c0-0.1,0.1-0.1,0.1-0.2c0,0,0-0.1,0.1-0.1c0-0.1,0.1-0.2,0.1-0.3c0,0,0-0.1,0-0.1c0.1-0.3,0.1-0.5,0-0.8
+			c0,0,0-0.1,0-0.1c0-0.1,0-0.2-0.1-0.3c0,0,0-0.1-0.1-0.1c0-0.1-0.1-0.2-0.1-0.2c-0.1-0.1-0.2-0.2-0.3-0.3l-0.8-0.8l-4.5-4.5
+			c0,0,0,0,0,0s0,0,0,0l-38.1-38.1v-6.8v-14v-21.4c0.6,0,1.2,0.1,1.8,0.1c5.8,0,11.6-2.2,16-6.6l2.2-2.2l18.9-18.9l18.6-18.6
+			c0,0,0,0,0,0l1.4-1.4c0,0,0,0,0.1-0.1c4.3-4.3,6.6-10,6.6-16c0-5.7-2.1-11.1-6-15.3c-0.1-0.3-0.3-0.6-0.5-0.9l-1.9-1.9
+			c0,0,0,0,0,0l-39.1-39.1v-3.7h26.4c0.1,0,0.2,0,0.3,0c0.1,0,0.2,0,0.3,0c10.7,0,19.4-8.7,19.4-19.4s-8.7-19.4-19.4-19.4h-46.1
+			c-3.1,0-5.7-2.5-5.7-5.7s2.5-5.7,5.7-5.7h69.2c0.6,0,1.1-0.1,1.7-0.3c10.3-1.6,18-10.6,18-21C-627.7-612.1-637.2-621.7-649-621.7z
+			 M-705.3-604v-5.7h56.4c5.1,0,9.3,4.2,9.3,9.3s-4.2,9.3-9.3,9.3h-67.7c-1.2,0-2.3,0.1-3.4,0.3c0,0,0,0.1-0.1,0.1
+			c0.2-0.4,0.4-0.9,0.5-1.3h2.2C-710.7-592-705.3-597.4-705.3-604z M-717.3-625.2c4.4,0,8,3.6,8,8v13.2c0,4.4-3.6,8-8,8h-2.9
+			c-4.4,0-8-3.6-8-8v-13.2c0-4.4,3.6-8,8-8H-717.3z M-820.9-648.1c-1.3,1.6-2.5,3.4-3.6,5.2C-823.4-644.7-822.2-646.4-820.9-648.1z
+			 M-834.1-596c-4.4,0-8-3.6-8-8v-13.2c0-4.3,3.4-7.8,7.7-8c-0.2,1.6-0.2,3.2-0.2,4.8v12.1c0,4.3,0.6,8.5,1.6,12.4
+			c0-0.1,0-0.1-0.1-0.2H-834.1z M-834.1-627.2c0,0.1,0,0.3-0.1,0.4C-834.2-627-834.2-627.1-834.1-627.2z M-832.5-594
+			C-832.5-594-832.5-594-832.5-594C-832.5-594-832.5-594-832.5-594z M-830.6-620.4c0-8.2,2.2-15.9,6.1-22.5
+			c11-3.5,22.2-5.3,33.2-5.3c14.1,0,28.4,2.9,42.5,8.7v50.3c-14.1,5.7-28.4,8.7-42.5,8.7c-11,0-22.2-1.8-33.2-5.3
+			c0.5,0.9,1.1,1.8,1.7,2.7c-4.9-7.1-7.8-15.8-7.8-25.1V-620.4z M-822.8-583.1c0.6,0.9,1.2,1.7,1.9,2.5
+			C-821.6-581.4-822.2-582.2-822.8-583.1z M-820.9-580.6c9.9,2.7,19.8,4.1,29.6,4.1c0,0,0,0,0,0c15,0,30.2-3.2,45.2-9.5
+			c0.7-0.3,1.2-1,1.2-1.8v-53c0-0.8-0.5-1.5-1.2-1.8c-15-6.3-30.2-9.5-45.2-9.5c-9.8,0-19.7,1.4-29.6,4.1
+			c8.1-10.2,20.7-16.7,34.7-16.7h21.1c21.5,0,39.5,15.4,43.5,35.7h0c-5.9,0.7-10.6,5.8-10.6,11.9v13.2c0,5.4,3.6,10,8.6,11.5
+			c-4.1,10.7-12.2,19.4-22.4,24.4h-59.3C-811.4-571.1-816.8-575.4-820.9-580.6z M-716.6-555.8h46.1c4.1,0,7.4,3.3,7.4,7.4
+			s-3.3,7.4-7.4,7.4c-0.1,0-0.2,0-0.3,0c-0.1,0-0.2,0-0.3,0h-29c-3.7-6.9-11-11.5-19.3-11.5h-4.5c0.1,0.1,0.1,0.2,0.2,0.2
+			c-4.1-5-9.6-8.7-16-10.4c-0.2-1.5-1-2.9-2.1-3.8c0.2,0.1,0.3,0.3,0.5,0.5c2.8-1.6,5.4-3.5,7.9-5.6c-0.2,0.2-0.4,0.4-0.6,0.5
+			C-733-562.5-725.6-555.8-716.6-555.8z M-732.4-572.7c0.3-0.2,0.5-0.5,0.7-0.7C-731.9-573.1-732.2-572.9-732.4-572.7z
+			 M-701.5-530.6v1.3l-19.3-19.3h1.3C-709.6-548.6-701.5-540.5-701.5-530.6z M-805.4-564.2h59.4c1.3,0,2.3,1,2.3,2.3s-1,2.3-2.3,2.3
+			h-59.4c-1.3,0-2.3-1-2.3-2.3S-806.7-564.2-805.4-564.2z M-807.5-567.8c0.3-0.1,0.6-0.2,0.9-0.3
+			C-806.9-568-807.2-567.9-807.5-567.8z M-806.4-568.1c0.3-0.1,0.7-0.1,1.1-0.1C-805.8-568.2-806.1-568.1-806.4-568.1z M-744.8-568
+			c0.3,0.1,0.6,0.2,0.9,0.3C-744.2-567.9-744.5-568-744.8-568z M-746-568.2c0.4,0,0.7,0,1.1,0.1C-745.3-568.1-745.7-568.2-746-568.2
+			z M-742-566.7c-0.2-0.2-0.4-0.3-0.7-0.5C-742.4-567-742.2-566.9-742-566.7z M-742.8-567.3c-0.3-0.2-0.5-0.3-0.8-0.4
+			C-743.4-567.6-743.1-567.4-742.8-567.3z M-808.8-567.2c-0.2,0.2-0.5,0.3-0.7,0.5C-809.2-566.9-809-567-808.8-567.2z M-807.8-567.7
+			c-0.3,0.1-0.6,0.3-0.8,0.4C-808.3-567.5-808-567.6-807.8-567.7z M-834.2-537.9c-0.3,1.7-0.4,3.4-0.4,5.2v37.6l-21.2-21.2
+			L-834.2-537.9z M-931.2-523.6c3.5-3.5,8.2-5.5,13.2-5.5c5,0,9.7,1.9,13.2,5.5l5.4,5.4l-32.8,19.8
+			C-938.4-505.7-938.1-516.7-931.2-523.6z M-929.4-495.5l32.9-19.9l7.6,7.6l-21,31.7L-929.4-495.5z M-862.8-456.6
+			c-0.2,0-0.3,0.1-0.4,0.2c-0.1,0.1-0.3,0.2-0.4,0.3c-3.5,3.5-8.2,5.5-13.2,5.5c-1.9,0-3.7-0.3-5.5-0.8c-0.4-0.1-0.7-0.2-1.1-0.4
+			c-2.5-0.9-4.8-2.4-6.7-4.4l-0.3-0.3c3.2-4.5,8.4-7.2,13.9-7.2c5.5,0,10.5,2.6,13.7,6.9L-862.8-456.6z M-859.8-459.5
+			c-4-5.1-10-8.1-16.6-8.1c-6.6,0-12.8,3.1-16.8,8.3L-907-473l21-31.7l7.9,7.9c0.8,0.8,2,0.8,2.8,0l6.7-6.7l26.4,26.4L-859.8-459.5z
+			 M-839.3-480l-26.4-26.4l7.1-7.1l24,24v4.7L-839.3-480z M-886.4-372.3c0-3,0.6-5.9,1.7-8.7c0,0,0-0.1,0.1-0.1
+			c1.1-3.5,3-6.6,5.6-9.2l3-3c1.5,2.7,2.4,5.7,2.4,8.8c0,7.9-5.3,14.8-12.8,17V-372.3z M-920.9-303c0.1-1.2,0.2-2.3,0.4-3.5h46.7
+			l-3.4-4h-42.4c3.3-11,12.2-19.6,23.3-22.6l25.5,30.1H-920.9z M-865.6-303l-26.2-31c0,0,0.1,0,0.1,0c0.4,0,0.7-0.1,1.1-0.1
+			c0.2,0,0.4,0,0.6-0.1c0.6,0,1.1-0.1,1.7-0.1c1.1,0,2-0.9,2-2v-4l43.9,37.2H-865.6z M-839.8-364.5c-0.4,0.4-0.6,0.9-0.6,1.4v52.7
+			h-4.7l-41.3-35v-18.1c9.7-2.3,16.8-11.1,16.8-21.1c0-4.2-1.2-8.2-3.4-11.7l4.7-4.7l32.5,32.5L-839.8-364.5z M-833-371.3
+			l-32.5-32.5l7.1-7.1l32.5,32.5L-833-371.3z M-823.1-381.2l-32.5-32.5l23.8-23.8h15.5l16.7,32.8L-823.1-381.2z M-769.7-406.3h-26.2
+			l-15.9-31.2h42.1V-406.3z M-754.8-330.6l-3.3-3.3c-2.1-2.1-3.8-4.6-5-7.4c0,0,0-0.1-0.1-0.1c-1.7-3.3-2.5-6.8-2.5-10.5v-4.3
+			c3,0.8,5.7,2.3,7.9,4.6C-752.2-346.1-751.1-337.4-754.8-330.6z M-737.4-299.2l29.5,2.5l-30,30
+			C-743.3-276.8-743.1-289.2-737.4-299.2z M-733.5-260.5c-0.8-0.9-1.5-1.8-2.2-2.7l33.1-33.1l4.5,0.4L-733.5-260.5z M-694.4-299.6
+			l-40.4-3.4c0,0,0.1-0.1,0.1-0.1c0.2-0.3,0.4-0.5,0.6-0.8c0.1-0.2,0.3-0.3,0.4-0.5c0.4-0.4,0.7-0.8,1.1-1.2
+			c0.1-0.1,0.2-0.2,0.2-0.3c0.5-0.8,0.4-1.8-0.3-2.5l-2.8-2.8l45.8-3.8l6.2-0.5l5.4-0.4L-694.4-299.6z M-681.9-322.7l-3.3,3.3
+			l-53.9,4.5l-12.8-12.8c5.2-8.4,4-19.7-3.1-26.8c-3-3-6.6-5-10.7-5.8v-6.6h46v5.6c0,0.5,0.2,1,0.6,1.4L-681.9-322.7z M-729.9-410.9
+			c2.9,2.9,6.4,4.8,10.2,5.8v20.1h-46v-19.4v-33.2h31.9c-1.8,3.3-2.7,6.9-2.7,10.7C-736.5-420.8-734.2-415.1-729.9-410.9z
+			 M-719.7-381v10h-46v-10H-719.7z M-700.7-413.7c-7.3,7.3-19.1,7.3-26.4,0s-7.3-19.1,0-26.4l5.5-5.5l21.8,30.9L-700.7-413.7z
+			 M-696.8-417.5l-21.8-30.9l7.5-7.5l29.9,22.8L-696.8-417.5z M-716.8-456v-24.5l5.5,5.5l6.7,6.7L-716.8-456z M-696.8-450l12.5-12.5
+			l7.9,7.9l-11.4,11.4L-696.8-450z M-660.1-482.2l0.1,0.1c0.1,0.3,0.3,0.6,0.5,0.8c3.5,3.5,5.5,8.2,5.5,13.2c0,1.2-0.1,2.5-0.4,3.7
+			c-0.7,3.6-2.5,6.9-5.1,9.5c0,0-0.1,0.1-0.1,0.1l-0.2,0.2c-4.5-3.2-7.2-8.4-7.2-13.9C-667-473.9-664.5-479-660.1-482.2z
+			 M-662.9-485.1c-5.1,4-8.1,10-8.1,16.6c0,6.6,3.1,12.8,8.3,16.8l-15.7,15.7l-6.2-4.7l12.4-12.4c0.8-0.8,0.8-2,0-2.8l-10.8-10.8
+			c-0.8-0.8-2.1-0.8-2.8,0l-14.3,14.3l-8.3-6.3l8-8c0.8-0.8,0.8-2,0-2.8l-6.7-6.7l26.4-26.4L-662.9-485.1z M-683.4-505.6l-26.4,26.4
+			l-7-7l-0.1-0.1l26.4-26.4L-683.4-505.6z M-693.3-515.4l-26.4,26.4l-1.1-1.1l-30.2-30.2c-0.8-0.8-2-0.8-2.8,0s-0.8,2,0,2.8
+			l32.7,32.7l0.4,0.4v32.5l-9.1,9.1c-0.4,0.4-0.8,0.9-1.2,1.3h-99.6v-91.2c0-12.4,8.3-22.8,19.7-26.1c1.1,2,3.2,3.3,5.6,3.3h59.4
+			c2.4,0,4.5-1.3,5.6-3.3c6.5,1.8,12,6.1,15.5,11.6c0,0,0,0,0,0c0.1,0.1,0.2,0.3,0.3,0.4L-693.3-515.4z M-646.4-583.4
+			c-0.1,0-0.2,0-0.4,0.1c-0.2,0.1-0.5,0.1-0.6,0.1h-69.2c-5.3,0-9.7,4.3-9.7,9.7s4.3,9.7,9.7,9.7h46.1c8.5,0,15.4,6.9,15.4,15.4
+			c0,8.5-6.9,15.4-15.3,15.4c-0.1,0-0.1,0-0.2,0c-0.1,0-0.2,0-0.3,0c-0.1,0-0.1,0-0.2,0h-26.5c-0.2-1.4-0.4-2.7-0.8-4h27.3
+			c0.1,0,0.1,0,0.2,0c0.1,0,0.2,0,0.3,0c0.1,0,0.1,0,0.2,0c6.3,0,11.3-5.1,11.3-11.4c0-6.3-5.1-11.4-11.4-11.4h-46.1
+			c-7.5,0-13.7-6.1-13.7-13.7c0-0.4,0-0.9,0.1-1.3c-0.1,0.1-0.3,0.2-0.4,0.4c3.3-3.4,6.1-7.3,8.4-11.5c1.7-0.8,3.6-1.2,5.6-1.2h67.7
+			c7.3,0,13.3-6,13.3-13.3c0-7.3-6-13.3-13.3-13.3h-56.4v-3.5c0-0.2,0-0.3,0-0.5h56.4c9.5,0,17.3,7.7,17.3,17.3
+			C-631.7-591.9-638-584.6-646.4-583.4z"/>
+		<path fill="#FF5C00" d="M-913.3-499.3c-3.8,0-6.8,3.1-6.8,6.8s3.1,6.8,6.8,6.8s6.8-3.1,6.8-6.8S-909.5-499.3-913.3-499.3z
+			 M-913.3-489.6c-1.6,0-2.8-1.3-2.8-2.8s1.3-2.8,2.8-2.8s2.8,1.3,2.8,2.8S-911.7-489.6-913.3-489.6z"/>
+	</g>
+	<g>
+		<g>
+			
+				<rect x="-1170.3" y="-749.4" transform="matrix(0.7071 -0.7071 0.7071 0.7071 176.5506 -930.2703)" fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="271.4" height="142.2"/>
+			
+				<line fill="none" stroke="#A9E1E8" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1116.8" y1="-696.4" x2="-1015.8" y2="-595.4"/>
+			
+				<line fill="none" stroke="#A9E1E8" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1052.8" y1="-760.4" x2="-951.9" y2="-659.4"/>
+			
+				<path fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1154.7-557.6l-0.6-0.6c-1.4-1.4-1.4-3.7,0-5.1l215.3-215.3c1.4-1.4,3.7-1.4,5.1,0l0.6,0.6c1.4,1.4,1.4,3.7,0,5.1l-215.3,215.3
+				C-1151-556.2-1153.3-556.2-1154.7-557.6z"/>
+		</g>
+		<g>
+			
+				<rect x="-1486.5" y="-432.2" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 -2561.2134 338.8029)" fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" width="271.4" height="142.2"/>
+			
+				<line fill="none" stroke="#A9E1E8" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1268.7" y1="-342.9" x2="-1369.6" y2="-443.9"/>
+			
+				<line fill="none" stroke="#A9E1E8" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-1332.6" y1="-278.9" x2="-1433.6" y2="-379.9"/>
+			
+				<path fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1230.7-481.7l0.6,0.6c1.4,1.4,1.4,3.7,0,5.1l-215.3,215.3c-1.4,1.4-3.7,1.4-5.1,0l-0.6-0.6c-1.4-1.4-1.4-3.7,0-5.1l215.3-215.3
+				C-1234.4-483.1-1232.1-483.1-1230.7-481.7z"/>
+		</g>
+		<g>
+			
+				<path fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1046.3-372.8L-1046.3-372.8c-1.6,1.6-4.1,1.6-5.7,0l-50.3-50.3c-1.6-1.6-1.6-4.1,0-5.7l0,0c1.6-1.6,4.1-1.6,5.7,0l50.3,50.3
+				C-1044.7-376.9-1044.7-374.4-1046.3-372.8z"/>
+			
+				<path fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1103.1-348.8L-1103.1-348.8c-2.2,0-4-1.8-4-4v-71.1c0-2.2,1.8-4,4-4l0,0c2.2,0,4,1.8,4,4v71.1
+				C-1099.1-350.6-1100.9-348.8-1103.1-348.8z"/>
+			
+				<path fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1022.3-429.6L-1022.3-429.6c0-2.2-1.8-4-4-4h-71.1c-2.2,0-4,1.8-4,4l0,0c0,2.2,1.8,4,4,4h71.1
+				C-1024.1-425.6-1022.3-427.4-1022.3-429.6z"/>
+		</g>
+		
+			<path fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1345.8-578.7l194.8,194.8l0,0c9.6,9.6,38.3-3.6,64.2-29.4s39-54.6,29.4-64.2l0,0l-194.8-194.8L-1345.8-578.7z"/>
+		
+			<ellipse transform="matrix(0.7071 -0.7071 0.7071 0.7071 61.8382 -1101.7588)" fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1299" cy="-625.5" rx="66.2" ry="24.6"/>
+		<g>
+			<path fill="none" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1177.7-597.7c9.6,9.6-3.6,38.3-29.4,64.2s-54.6,39-64.2,29.4"/>
+			<path fill="none" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-1132-552.1c9.6,9.6-3.6,38.3-29.4,64.2s-54.6,39-64.2,29.4"/>
+		</g>
+		
+			<path fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1296-622.5L-1296-622.5c-1.6,1.6-4.1,1.6-5.7,0l-50.3-50.3c-1.6-1.6-1.6-4.1,0-5.7l0,0c1.6-1.6,4.1-1.6,5.7,0l50.3,50.3
+			C-1294.4-626.6-1294.4-624.1-1296-622.5z"/>
+		
+			<path fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1301.3-749.4L-1301.3-749.4L-1301.3-749.4c-12.5-12.5-49.8,4.6-83.4,38.2c-33.6,33.6-50.7,70.9-38.2,83.4l0,0l0,0l0,0l0,0
+			c0,0,34.4,34.4,74.6,9.7l0,0c10.1-5.6,21.3-14.1,31.9-24.8c10.7-10.7,19.2-21.8,24.8-31.9l0,0
+			C-1266.9-715-1301.3-749.4-1301.3-749.4L-1301.3-749.4L-1301.3-749.4z"/>
+		
+			<ellipse transform="matrix(0.7071 -0.7071 0.7071 0.7071 87.9676 -1164.8407)" fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" cx="-1362.1" cy="-688.6" rx="86" ry="31.9"/>
+		
+			<path fill="#FFFFFF" stroke="#A9E1E8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-1355.6-682.1L-1355.6-682.1c-1.6,1.6-4.1,1.6-5.7,0l-50.3-50.3c-1.6-1.6-1.6-4.1,0-5.7l0,0c1.6-1.6,4.1-1.6,5.7,0l50.3,50.3
+			C-1354-686.2-1354-683.7-1355.6-682.1z"/>
+	</g>
+	<g>
+		
+			<path fill="#FFFFFF" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-924.5-590.5c5.6-5.6,6.8-13.9,3.7-20.7l-9.7,9.7l-8.8-0.4l-0.4-8.8l9.7-9.7c-6.8-3.1-15.1-1.9-20.7,3.7
+			c-4.8,4.8-6.4,11.5-4.8,17.6c0.5,2.2-0.2,4.4-1.8,6l-36.4,36.4c-2.5,2.5-2.8,6.7-0.3,9.2c2.5,2.7,6.7,2.7,9.3,0.1l36.6-36.6
+			c1.6-1.6,3.9-2.3,6-1.8C-936-584.1-929.3-585.7-924.5-590.5z"/>
+		
+			<line fill="none" stroke="#FF5C00" stroke-width="4" stroke-linejoin="round" stroke-miterlimit="10" x1="-939.3" y1="-601.9" x2="-952.4" y2="-615"/>
+	</g>
+	<g>
+		
+			<polygon fill="none" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" points="
+			-988.2,-478.6 -996.3,-482.2 -1000.8,-477.7 -997.2,-469.6 -989.1,-465.9 -989.1,-466 -965.3,-442.2 -960.9,-446.7 -984.6,-470.4 
+			-984.6,-470.5 		"/>
+		
+			<path fill="#FFFFFF" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+			M-926.1-407.5L-926.1-407.5c-2.6,2.6-6.8,2.6-9.3,0l-35.9-35.9l9.3-9.3l35.9,35.9C-923.5-414.2-923.5-410-926.1-407.5z"/>
+	</g>
+	<path fill="none" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1190.7-783.2c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-1190.1-784.1-1190.1-783.3-1190.7-783.2z"/>
+	<path fill="none" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-799.9-743.5c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-799.3-744.5-799.3-743.6-799.9-743.5z"/>
+	<path fill="none" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-614.2-724.6c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-613.6-725.6-613.6-724.8-614.2-724.6z"/>
+	<path fill="none" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-549.1-433.1c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-548.5-434.1-548.5-433.2-549.1-433.1z"/>
+	<path fill="none" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-670.5-229.4c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-669.9-230.3-669.9-229.5-670.5-229.4z"/>
+	<path fill="none" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-997.4-288.7c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-996.8-289.6-996.8-288.8-997.4-288.7z"/>
+	<path fill="none" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1227-219.9c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-1226.4-220.9-1226.4-220.1-1227-219.9z"/>
+	<path fill="none" stroke="#FF5C00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="
+		M-1424.6-515.6c-4.5,1.1-7.3,3.9-8.4,8.4c-0.2,0.6-1,0.6-1.1,0c-1.1-4.5-3.9-7.3-8.4-8.4c-0.6-0.2-0.6-1,0-1.1
+		c4.5-1.1,7.3-3.9,8.4-8.4c0.2-0.6,1-0.6,1.1,0c1.1,4.5,3.9,7.3,8.4,8.4C-1424-516.6-1424-515.7-1424.6-515.6z"/>
+	<g>
+		<path fill="#FF5C00" d="M-680.8-477.4c-4.4,0-8-3.6-8-8c0-4.4,3.6-8,8-8c4.4,0,8,3.6,8,8C-672.8-481-676.4-477.4-680.8-477.4z
+			 M-680.8-489.5c-2.2,0-4,1.8-4,4c0,2.2,1.8,4,4,4c2.2,0,4-1.8,4-4C-676.8-487.7-678.6-489.5-680.8-489.5z"/>
+	</g>
+	<g>
+		<path fill="#FF5C00" d="M-862.3-304.2c-3.5,0-6.3-2.8-6.3-6.3s2.8-6.3,6.3-6.3s6.3,2.8,6.3,6.3S-858.8-304.2-862.3-304.2z
+			 M-862.3-312.8c-1.3,0-2.3,1-2.3,2.3c0,1.3,1,2.3,2.3,2.3s2.3-1,2.3-2.3C-860-311.8-861-312.8-862.3-312.8z"/>
+	</g>
+	<g>
+		<path fill="#FF5C00" d="M-697.7-301.3c-1.7,0-3.3-0.7-4.5-1.9c-2.5-2.5-2.5-6.5,0-8.9c1.2-1.2,2.8-1.9,4.5-1.9s3.3,0.7,4.5,1.9
+			c1.2,1.2,1.9,2.8,1.9,4.5s-0.7,3.3-1.9,4.5C-694.5-302-696.1-301.3-697.7-301.3z M-697.7-310c-0.6,0-1.2,0.2-1.6,0.7
+			c-0.9,0.9-0.9,2.4,0,3.3c0.9,0.9,2.4,0.9,3.3,0c0.4-0.4,0.7-1,0.7-1.6c0-0.6-0.2-1.2-0.7-1.6C-696.5-309.8-697.1-310-697.7-310z"
+			/>
+	</g>
+	<g>
+		<g>
+			<path fill="#A9E1E8" d="M730.8-608c0.9,2.7,1.6,5.7,2,8.9c0.4,3.2,3.2,5.7,6.4,5.7c0.3,0,0.5,0,0.8-0.1c1.7-0.2,3.3-1.1,4.3-2.5
+				c1.1-1.4,1.5-3.1,1.3-4.8c-0.5-4.1-1.4-8-2.6-11.5c-0.9-2.6-3.4-4.4-6.2-4.4c-0.7,0-1.4,0.1-2.1,0.3
+				C731.5-615.1,729.7-611.4,730.8-608z M736.2-612.4c0.3-0.1,0.5-0.1,0.8-0.1c1.1,0,2,0.7,2.4,1.7c1.1,3.3,1.9,6.9,2.4,10.7
+				c0.1,0.7-0.1,1.3-0.5,1.8c-0.4,0.5-1,0.9-1.7,0.9c-1.4,0.2-2.6-0.8-2.8-2.2c-0.4-3.5-1.2-6.8-2.2-9.7
+				C734.2-610.6,734.9-612,736.2-612.4z"/>
+			<path fill="#A9E1E8" d="M684-626.4c0.5,0,1.1-0.1,1.6-0.2c0.2-0.1,5.8-1.4,13.1-1.4c7.8,0,18.7,1.6,25.9,9.3c1.2,1.3,3,2,4.7,2
+				c1.7,0,3.2-0.6,4.4-1.8c1.3-1.2,2-2.8,2-4.5c0.1-1.7-0.6-3.4-1.8-4.7c-10.4-11.1-25-13.4-35.4-13.4c-8.9,0-15.5,1.6-16.3,1.8
+				c-1.7,0.4-3.1,1.5-4,3c-0.9,1.5-1.1,3.2-0.7,4.9C678.4-628.4,681-626.4,684-626.4z M681.9-634.2c0.3-0.6,0.9-1,1.5-1.1
+				c0.3-0.1,6.7-1.7,15.3-1.7c9.6,0,23.1,2.1,32.5,12.2c0.5,0.5,0.7,1.1,0.7,1.8c0,0.7-0.3,1.3-0.8,1.7c-1,0.9-2.6,0.9-3.5-0.1
+				c-8.2-8.7-20.2-10.6-28.8-10.6c-7.8,0-13.8,1.5-14.1,1.5c-1.3,0.3-2.7-0.5-3-1.8C681.4-632.9,681.5-633.6,681.9-634.2z"/>
+			<path fill="#A9E1E8" d="M728.9-539.8h-43.5c-5.3,0-9.6,4.3-9.6,9.6v72.5c0,5.3,4.3,9.6,9.6,9.6h43.5c5.3,0,9.6-4.3,9.6-9.6v-72.5
+				C738.6-535.5,734.3-539.8,728.9-539.8z M734.6-457.6c0,3.1-2.5,5.6-5.6,5.6h-43.5c-3.1,0-5.6-2.5-5.6-5.6v-72.5
+				c0-3.1,2.5-5.6,5.6-5.6h43.5c3.1,0,5.6,2.5,5.6,5.6V-457.6z"/>
+			<path fill="#A9E1E8" d="M725.8-533.7c-3.9,0-7,3.2-7,7s3.2,7,7,7c3.9,0,7-3.2,7-7S729.7-533.7,725.8-533.7z M725.8-523.6
+				c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S727.5-523.6,725.8-523.6z"/>
+			<path fill="#A9E1E8" d="M725.8-511.8c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7c3.9,0,7-3.2,7-7C732.8-508.6,729.7-511.8,725.8-511.8z
+				 M725.8-501.7c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S727.5-501.7,725.8-501.7z"/>
+			<path fill="#A9E1E8" d="M725.8-489.9c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7c3.9,0,7-3.2,7-7C732.8-486.7,729.7-489.9,725.8-489.9z
+				 M725.8-479.8c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S727.5-479.8,725.8-479.8z"/>
+			<path fill="#A9E1E8" d="M725.8-468c-3.9,0-7,3.2-7,7s3.2,7,7,7c3.9,0,7-3.2,7-7S729.7-468,725.8-468z M725.8-457.9
+				c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S727.5-457.9,725.8-457.9z"/>
+			<path fill="#A9E1E8" d="M709.5-533.7H689c-3.9,0-7,3.2-7,7s3.2,7,7,7h20.5c3.9,0,7-3.2,7-7S713.4-533.7,709.5-533.7z
+				 M709.5-523.6H689c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3S711.2-523.6,709.5-523.6z"/>
+			<path fill="#A9E1E8" d="M709.5-511.8H689c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7h20.5c3.9,0,7-3.2,7-7
+				C716.5-508.6,713.4-511.8,709.5-511.8z M709.5-501.7H689c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3
+				S711.2-501.7,709.5-501.7z"/>
+			<path fill="#A9E1E8" d="M709.5-489.9H689c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7h20.5c3.9,0,7-3.2,7-7
+				C716.5-486.7,713.4-489.9,709.5-489.9z M709.5-479.8H689c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3
+				S711.2-479.8,709.5-479.8z"/>
+			<path fill="#A9E1E8" d="M709.5-468H689c-3.9,0-7,3.2-7,7s3.2,7,7,7h20.5c3.9,0,7-3.2,7-7S713.4-468,709.5-468z M709.5-457.9H689
+				c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3S711.2-457.9,709.5-457.9z"/>
+			<path fill="#A9E1E8" d="M850-621.7h-57.3c-1.8-4.4-6.1-7.5-11.1-7.5h-0.3c-4.2-22.5-23.9-39.6-47.6-39.6h-21.1
+				c-23.7,0-43.4,17.1-47.6,39.6h-0.3c-6.6,0-12,5.4-12,12v13.2c0,6.6,5.4,12,12,12h2.2c3.9,11,11.8,20.2,21.8,25.9
+				c0.1-0.2,0.3-0.3,0.5-0.5c-1.1,1-1.9,2.3-2.1,3.8c-8.9,2.4-16.2,8.6-20,16.8c0-0.1,0.1-0.1,0.1-0.2l-45.1,45.1l-8.2-8.2l-9.9-9.9
+				l-7.2-7.2c-4.3-4.3-10-6.6-16-6.6h0c-6,0-11.7,2.4-16,6.6c-8.8,8.8-8.8,23.2,0,32l23.1,23.1l16.6,16.6c0,0,0,0,0,0l1.4,1.4l0,0
+				c0,0,0,0,0.1,0.1c2.8,2.8,6.2,4.8,10,5.8c0.5,0.1,1.1,0.3,1.6,0.4c1.5,0.3,2.9,0.4,4.5,0.4c5.7,0,11.1-2.1,15.3-6
+				c0.3-0.1,0.6-0.3,0.9-0.5l1.9-1.9c0,0,0,0,0,0l24.1-24.1v38.7l-25.2,25.2l-9.9,9.9l-7.3,7.3c0,0,0,0,0,0l-4.7,4.7
+				c-3,3-5.3,6.7-6.6,10.8c-1.3,3.2-2,6.7-2,10.2v7.2v20.7v6.4c-0.8,0.1-1.7,0.2-2.5,0.3c-0.2,0-0.4,0.1-0.6,0.1
+				c-0.8,0.1-1.5,0.3-2.3,0.4c-0.1,0-0.2,0-0.3,0c0,0-0.1,0-0.1,0c-13.8,3.2-24.8,14.3-27.9,28.2c0,0.1-0.1,0.2-0.1,0.4
+				c-0.5,2.5-0.8,5.1-0.8,7.7c0,1.1,0.9,2,2,2h56.5h28.1c1.1,0,2-0.9,2-2v-1.2v-60.1l4.8-4.8l9.9-9.9l25.4-25.4h26.6v19.4v14v10.3
+				v6.7v0c0,1.6,0.1,3.2,0.4,4.8c0.5,2.6,1.3,5.1,2.5,7.5c1.4,3.2,3.3,6.1,5.8,8.6l19.7,19.7l0,0l4.5,4.5c-0.5,0.6-1.1,1.3-1.6,2
+				c-0.1,0.2-0.3,0.3-0.4,0.5c-0.5,0.6-0.9,1.2-1.3,1.9c0,0.1-0.1,0.1-0.1,0.2c0,0,0,0.1-0.1,0.1c-7.5,12.1-7.4,27.6,0.2,39.7
+				c0.1,0.1,0.1,0.2,0.2,0.3c1.4,2.1,3,4.2,4.9,6.1c0.4,0.4,0.9,0.6,1.4,0.6s1-0.2,1.4-0.6l59.8-59.8c0.1-0.1,0.2-0.2,0.3-0.3
+				c0-0.1,0.1-0.1,0.1-0.2c0,0,0-0.1,0.1-0.1c0-0.1,0.1-0.2,0.1-0.3c0,0,0-0.1,0-0.1c0.1-0.3,0.1-0.5,0-0.8c0,0,0-0.1,0-0.1
+				c0-0.1,0-0.2-0.1-0.3c0,0,0-0.1-0.1-0.1c0-0.1-0.1-0.2-0.1-0.2c-0.1-0.1-0.2-0.2-0.3-0.3l-0.8-0.8l-4.5-4.5c0,0,0,0,0,0s0,0,0,0
+				l-38.1-38.1v-6.8v-14v-21.4c0.6,0,1.2,0.1,1.8,0.1c5.8,0,11.6-2.2,16-6.6l2.2-2.2l18.9-18.9l18.6-18.6c0,0,0,0,0,0l1.4-1.4
+				c0,0,0,0,0.1-0.1c4.3-4.3,6.6-10,6.6-16c0-5.7-2.1-11.1-6-15.3c-0.1-0.3-0.3-0.6-0.5-0.9l-1.9-1.9l0,0l-39.1-39.1v-3.7h26.4
+				c0.1,0,0.2,0,0.3,0c0.1,0,0.2,0,0.3,0c10.7,0,19.4-8.7,19.4-19.4s-8.7-19.4-19.4-19.4h-46.1c-3.1,0-5.7-2.5-5.7-5.7
+				s2.5-5.7,5.7-5.7h69.2c0.6,0,1.1-0.1,1.7-0.3c10.3-1.6,18-10.6,18-21C871.3-612.1,861.8-621.7,850-621.7z M793.7-604v-5.7H850
+				c5.1,0,9.3,4.2,9.3,9.3s-4.2,9.3-9.3,9.3h-67.7c-1.2,0-2.3,0.1-3.4,0.3c0,0,0,0.1-0.1,0.1c0.2-0.4,0.4-0.9,0.5-1.3h2.2
+				C788.3-592,793.7-597.4,793.7-604z M781.7-625.2c4.4,0,8,3.6,8,8v13.2c0,4.4-3.6,8-8,8h-2.9c-4.4,0-8-3.6-8-8v-13.2
+				c0-4.4,3.6-8,8-8H781.7z M678.1-648.1c-1.3,1.6-2.5,3.4-3.6,5.2C675.6-644.7,676.8-646.4,678.1-648.1z M664.9-596
+				c-4.4,0-8-3.6-8-8v-13.2c0-4.3,3.4-7.8,7.7-8c-0.2,1.6-0.2,3.2-0.2,4.8v12.1c0,4.3,0.6,8.5,1.6,12.4c0-0.1,0-0.1-0.1-0.2H664.9z
+				 M664.9-627.2c0,0.1,0,0.3-0.1,0.4C664.8-627,664.8-627.1,664.9-627.2z M666.5-594C666.5-594,666.5-594,666.5-594
+				C666.5-594,666.5-594,666.5-594z M668.4-620.4c0-8.2,2.2-15.9,6.1-22.5c11-3.5,22.2-5.3,33.2-5.3c14.1,0,28.4,2.9,42.5,8.7v50.3
+				c-14.1,5.7-28.4,8.7-42.5,8.7c-11,0-22.2-1.8-33.2-5.3c0.5,0.9,1.1,1.8,1.7,2.7c-4.9-7.1-7.8-15.8-7.8-25.1V-620.4z M676.2-583.1
+				c0.6,0.9,1.2,1.7,1.9,2.5C677.4-581.4,676.8-582.2,676.2-583.1z M678.1-580.6c9.9,2.7,19.8,4.1,29.6,4.1h0
+				c15,0,30.2-3.2,45.2-9.5c0.7-0.3,1.2-1,1.2-1.8v-53c0-0.8-0.5-1.5-1.2-1.8c-15-6.3-30.2-9.5-45.2-9.5c-9.8,0-19.7,1.4-29.6,4.1
+				c8.1-10.2,20.7-16.7,34.7-16.7h21.1c21.5,0,39.5,15.4,43.5,35.7h0c-5.9,0.7-10.6,5.8-10.6,11.9v13.2c0,5.4,3.6,10,8.6,11.5
+				c-4.1,10.7-12.2,19.4-22.4,24.4h-59.3C687.6-571.1,682.2-575.4,678.1-580.6z M782.4-555.8h46.1c4.1,0,7.4,3.3,7.4,7.4
+				s-3.3,7.4-7.4,7.4c-0.1,0-0.2,0-0.3,0c-0.1,0-0.2,0-0.3,0h-29c-3.7-6.9-11-11.5-19.3-11.5h-4.5c0.1,0.1,0.1,0.2,0.2,0.2
+				c-4.1-5-9.6-8.7-16-10.4c-0.2-1.5-1-2.9-2.1-3.8c0.2,0.1,0.3,0.3,0.5,0.5c2.8-1.6,5.4-3.5,7.9-5.6c-0.2,0.2-0.4,0.4-0.6,0.5
+				C766-562.5,773.4-555.8,782.4-555.8z M766.6-572.7c0.3-0.2,0.5-0.5,0.7-0.7C767.1-573.1,766.8-572.9,766.6-572.7z M797.5-530.6
+				v1.3l-19.3-19.3h1.3C789.4-548.6,797.5-540.5,797.5-530.6z M693.6-564.2H753c1.3,0,2.3,1,2.3,2.3s-1,2.3-2.3,2.3h-59.4
+				c-1.3,0-2.3-1-2.3-2.3S692.3-564.2,693.6-564.2z M691.5-567.8c0.3-0.1,0.6-0.2,0.9-0.3C692.1-568,691.8-567.9,691.5-567.8z
+				 M692.6-568.1c0.3-0.1,0.7-0.1,1.1-0.1C693.2-568.2,692.9-568.1,692.6-568.1z M754.2-568c0.3,0.1,0.6,0.2,0.9,0.3
+				C754.8-567.9,754.5-568,754.2-568z M753-568.2c0.4,0,0.7,0,1.1,0.1C753.7-568.1,753.3-568.2,753-568.2z M757-566.7
+				c-0.2-0.2-0.4-0.3-0.7-0.5C756.6-567,756.8-566.9,757-566.7z M756.2-567.3c-0.3-0.2-0.5-0.3-0.8-0.4
+				C755.6-567.6,755.9-567.4,756.2-567.3z M690.2-567.2c-0.2,0.2-0.5,0.3-0.7,0.5C689.8-566.9,690-567,690.2-567.2z M691.2-567.7
+				c-0.3,0.1-0.6,0.3-0.8,0.4C690.7-567.5,691-567.6,691.2-567.7z M664.8-537.9c-0.3,1.7-0.4,3.4-0.4,5.2v37.6l-21.2-21.2
+				L664.8-537.9z M567.8-523.6c3.5-3.5,8.2-5.5,13.2-5.5c5,0,9.7,1.9,13.2,5.5l5.4,5.4l-32.8,19.8
+				C560.6-505.7,560.9-516.7,567.8-523.6z M569.6-495.5l32.9-19.9l7.6,7.6l-21,31.7L569.6-495.5z M636.2-456.6
+				c-0.2,0-0.3,0.1-0.4,0.2c-0.1,0.1-0.3,0.2-0.4,0.3c-3.5,3.5-8.2,5.5-13.2,5.5c-1.9,0-3.7-0.3-5.5-0.8c-0.4-0.1-0.7-0.2-1.1-0.4
+				c-2.5-0.9-4.8-2.4-6.7-4.4l-0.3-0.3c3.2-4.5,8.4-7.2,13.9-7.2c5.5,0,10.5,2.6,13.7,6.9L636.2-456.6z M639.2-459.5
+				c-4-5.1-10-8.1-16.6-8.1c-6.6,0-12.8,3.1-16.8,8.3L592-473l21-31.7l7.9,7.9c0.8,0.8,2,0.8,2.8,0l6.7-6.7l26.4,26.4L639.2-459.5z
+				 M659.7-480l-26.4-26.4l7.1-7.1l24,24v4.7L659.7-480z M612.6-372.3c0-3,0.6-5.9,1.7-8.7c0,0,0-0.1,0.1-0.1c1.1-3.5,3-6.6,5.6-9.2
+				l3-3c1.5,2.7,2.4,5.7,2.4,8.8c0,7.9-5.3,14.8-12.8,17V-372.3z M578.1-303c0.1-1.2,0.2-2.3,0.4-3.5h46.7l-3.4-4h-42.4
+				c3.3-11,12.2-19.6,23.3-22.6l25.5,30.1H578.1z M633.4-303l-26.2-31c0,0,0.1,0,0.1,0c0.4,0,0.7-0.1,1.1-0.1c0.2,0,0.4,0,0.6-0.1
+				c0.6,0,1.1-0.1,1.7-0.1c1.1,0,2-0.9,2-2v-4l43.9,37.2H633.4z M659.2-364.5c-0.4,0.4-0.6,0.9-0.6,1.4v52.7h-4.7l-41.3-35v-18.1
+				c9.7-2.3,16.8-11.1,16.8-21.1c0-4.2-1.2-8.2-3.4-11.7l4.7-4.7l32.5,32.5L659.2-364.5z M666-371.3l-32.5-32.5l7.1-7.1l32.5,32.5
+				L666-371.3z M675.9-381.2l-32.5-32.5l23.8-23.8h15.5l16.7,32.8L675.9-381.2z M729.3-406.3h-26.2l-15.9-31.2h42.1V-406.3z
+				 M744.2-330.6l-3.3-3.3c-2.1-2.1-3.8-4.6-5-7.4c0,0,0-0.1-0.1-0.1c-1.7-3.3-2.5-6.8-2.5-10.5v-4.3c3,0.8,5.7,2.3,7.9,4.6
+				C746.8-346.1,747.9-337.4,744.2-330.6z M761.6-299.2l29.5,2.5l-30,30C755.7-276.8,755.9-289.2,761.6-299.2z M765.5-260.5
+				c-0.8-0.9-1.5-1.8-2.2-2.7l33.1-33.1l4.5,0.4L765.5-260.5z M804.6-299.6l-40.4-3.4c0,0,0.1-0.1,0.1-0.1c0.2-0.3,0.4-0.5,0.6-0.8
+				c0.1-0.2,0.3-0.3,0.4-0.5c0.4-0.4,0.7-0.8,1.1-1.2c0.1-0.1,0.2-0.2,0.2-0.3c0.5-0.8,0.4-1.8-0.3-2.5l-2.8-2.8l45.8-3.8l6.2-0.5
+				l5.4-0.4L804.6-299.6z M817.1-322.7l-3.3,3.3l-53.9,4.5l-12.8-12.8c5.2-8.4,4-19.7-3.1-26.8c-3-3-6.6-5-10.7-5.8v-6.6h46v5.6
+				c0,0.5,0.2,1,0.6,1.4L817.1-322.7z M769.1-410.9c2.9,2.9,6.4,4.8,10.2,5.8v20.1h-46v-19.4v-33.2h31.9c-1.8,3.3-2.7,6.9-2.7,10.7
+				C762.5-420.8,764.8-415.1,769.1-410.9z M779.3-381v10h-46v-10H779.3z M798.3-413.7c-7.3,7.3-19.1,7.3-26.4,0s-7.3-19.1,0-26.4
+				l5.5-5.5l21.8,30.9L798.3-413.7z M802.2-417.5l-21.8-30.9l7.5-7.5l29.9,22.8L802.2-417.5z M782.2-456v-24.5l5.5,5.5l6.7,6.7
+				L782.2-456z M802.2-450l12.5-12.5l7.9,7.9l-11.4,11.4L802.2-450z M838.9-482.2l0.1,0.1c0.1,0.3,0.3,0.6,0.5,0.8
+				c3.5,3.5,5.5,8.2,5.5,13.2c0,1.2-0.1,2.5-0.4,3.7c-0.7,3.6-2.5,6.9-5.1,9.5c0,0-0.1,0.1-0.1,0.1l-0.2,0.2
+				c-4.5-3.2-7.2-8.4-7.2-13.9C832-473.9,834.5-479,838.9-482.2z M836.1-485.1c-5.1,4-8.1,10-8.1,16.6c0,6.6,3.1,12.8,8.3,16.8
+				L820.6-436l-6.2-4.7l12.4-12.4c0.8-0.8,0.8-2,0-2.8l-10.8-10.8c-0.8-0.8-2.1-0.8-2.8,0L799-452.5l-8.3-6.3l8-8
+				c0.8-0.8,0.8-2,0-2.8l-6.7-6.7l26.4-26.4L836.1-485.1z M815.6-505.6l-26.4,26.4l-7-7l-0.1-0.1l26.4-26.4L815.6-505.6z
+				 M805.7-515.4l-26.4,26.4l-1.1-1.1L748-520.4c-0.8-0.8-2-0.8-2.8,0s-0.8,2,0,2.8l32.7,32.7l0.4,0.4v32.5l-9.1,9.1
+				c-0.4,0.4-0.8,0.9-1.2,1.3h-99.6v-91.2c0-12.4,8.3-22.8,19.7-26.1c1.1,2,3.2,3.3,5.6,3.3H753c2.4,0,4.5-1.3,5.6-3.3
+				c6.5,1.8,12,6.1,15.5,11.6l0,0c0.1,0.1,0.2,0.3,0.3,0.4L805.7-515.4z M852.6-583.4c-0.1,0-0.2,0-0.4,0.1
+				c-0.2,0.1-0.5,0.1-0.6,0.1h-69.2c-5.3,0-9.7,4.3-9.7,9.7s4.3,9.7,9.7,9.7h46.1c8.5,0,15.4,6.9,15.4,15.4
+				c0,8.5-6.9,15.4-15.3,15.4c-0.1,0-0.1,0-0.2,0c-0.1,0-0.2,0-0.3,0c-0.1,0-0.1,0-0.2,0h-26.5c-0.2-1.4-0.4-2.7-0.8-4h27.3
+				c0.1,0,0.1,0,0.2,0c0.1,0,0.2,0,0.3,0c0.1,0,0.1,0,0.2,0c6.3,0,11.3-5.1,11.3-11.4c0-6.3-5.1-11.4-11.4-11.4h-46.1
+				c-7.5,0-13.7-6.1-13.7-13.7c0-0.4,0-0.9,0.1-1.3c-0.1,0.1-0.3,0.2-0.4,0.4c3.3-3.4,6.1-7.3,8.4-11.5c1.7-0.8,3.6-1.2,5.6-1.2H850
+				c7.3,0,13.3-6,13.3-13.3c0-7.3-6-13.3-13.3-13.3h-56.4v-3.5c0-0.2,0-0.3,0-0.5H850c9.5,0,17.3,7.7,17.3,17.3
+				C867.3-591.9,861-584.6,852.6-583.4z"/>
+			<path fill="#A9E1E8" d="M585.7-499.3c-3.8,0-6.8,3.1-6.8,6.8s3.1,6.8,6.8,6.8s6.8-3.1,6.8-6.8S589.5-499.3,585.7-499.3z
+				 M585.7-489.6c-1.6,0-2.8-1.3-2.8-2.8s1.3-2.8,2.8-2.8s2.8,1.3,2.8,2.8S587.3-489.6,585.7-489.6z"/>
+			<g>
+				<path fill="#A9E1E8" d="M818.2-477.4c-4.4,0-8-3.6-8-8c0-4.4,3.6-8,8-8c4.4,0,8,3.6,8,8C826.2-481,822.6-477.4,818.2-477.4z
+					 M818.2-489.5c-2.2,0-4,1.8-4,4c0,2.2,1.8,4,4,4c2.2,0,4-1.8,4-4C822.2-487.7,820.4-489.5,818.2-489.5z"/>
+			</g>
+			<g>
+				<path fill="#A9E1E8" d="M636.7-304.2c-3.5,0-6.3-2.8-6.3-6.3s2.8-6.3,6.3-6.3s6.3,2.8,6.3,6.3S640.2-304.2,636.7-304.2z
+					 M636.7-312.8c-1.3,0-2.3,1-2.3,2.3c0,1.3,1,2.3,2.3,2.3s2.3-1,2.3-2.3C639-311.8,638-312.8,636.7-312.8z"/>
+			</g>
+			<g>
+				<path fill="#A9E1E8" d="M801.3-301.3c-1.7,0-3.3-0.7-4.5-1.9c-2.5-2.5-2.5-6.5,0-8.9c1.2-1.2,2.8-1.9,4.5-1.9s3.3,0.7,4.5,1.9
+					c1.2,1.2,1.9,2.8,1.9,4.5s-0.7,3.3-1.9,4.5C804.5-302,802.9-301.3,801.3-301.3z M801.3-310c-0.6,0-1.2,0.2-1.6,0.7
+					c-0.9,0.9-0.9,2.4,0,3.3c0.9,0.9,2.4,0.9,3.3,0c0.4-0.4,0.7-1,0.7-1.6c0-0.6-0.2-1.2-0.7-1.6C802.5-309.8,801.9-310,801.3-310z"
+					/>
+			</g>
+		</g>
+		<g>
+			<path fill="#A9E1E8" d="M612-725.3l-46-46l0.1-0.1c1.1-1.1,1.6-2.5,1.6-4s-0.6-2.9-1.6-4l-0.6-0.6c-1.1-1.1-2.5-1.6-4-1.6
+				s-2.9,0.6-4,1.6l-0.1,0.1l-46-46c-0.8-0.8-2-0.8-2.8,0L316.7-634c-0.8,0.8-0.8,2,0,2.8l46,46l2.8-2.8l-44.6-44.6l61.1-61.1
+				l44.6,44.6l-77,76.9l2.8,2.8l207.8-207.8c0.3-0.3,0.7-0.5,1.1-0.5s0.8,0.2,1.1,0.5l0.6,0.6c0.3,0.3,0.5,0.7,0.5,1.1
+				s-0.2,0.8-0.5,1.1L355.4-566.5l2.8,2.8l13-13l46,46c0.4,0.4,0.9,0.6,1.4,0.6s1-0.2,1.4-0.6L612-722.5
+				C612.8-723.3,612.8-724.5,612-725.3z M510-821.6l44.6,44.6l-61.1,61.1l-44.6-44.6L510-821.6z M384.9-696.6l61.1-61.1l44.6,44.6
+				l-61.1,61.1L384.9-696.6z M499.2-704.6l44.6,44.6l-61.1,61.1L438-643.4L499.2-704.6z M418.7-534.9l-44.6-44.6l61.1-61.1
+				l44.6,44.6L418.7-534.9z M546.6-662.8L502-707.4l61.1-61.1l44.6,44.6L546.6-662.8z"/>
+			<path fill="#A9E1E8" d="M249.8-454.1l12.6-12.6l-2.8-2.8L52.2-262.2c-0.6,0.6-1.7,0.6-2.3,0l-0.6-0.6c-0.6-0.6-0.6-1.7,0-2.3
+				l207.4-207.4l-2.8-2.8l-13,13l0.4-0.4l-46-46c-0.8-0.8-2-0.8-2.8,0L0.6-316.8c-0.8,0.8-0.8,2,0,2.8l46,46l2.8-2.8L4.8-315.4
+				L66-376.5l44.6,44.6l2.8-2.8l-44.6-44.6l61.1-61.1l44.6,44.6l2.8-2.8l-44.6-44.6l61.1-61.1l44.6,44.6l-192,192
+				c-2.2,2.2-2.2,5.7,0,7.9l0.6,0.6c1.1,1.1,2.5,1.6,4,1.6s2.9-0.6,4-1.6l0.1-0.1l46,46c0.4,0.4,0.9,0.6,1.4,0.6s1-0.2,1.4-0.6
+				l191.9-191.9c0.4-0.4,0.6-0.9,0.6-1.4s-0.2-1-0.6-1.4L249.8-454.1z M183.1-387.3l44.6,44.6l-61.1,61.1l-44.6-44.6L183.1-387.3z
+				 M102.6-217.6L58-262.2l61.1-61.1l44.6,44.6L102.6-217.6z M230.5-345.6l-44.6-44.6l61.1-61.1l44.6,44.6L230.5-345.6z"/>
+			<path fill="#A9E1E8" d="M472.7-435.7h-39.3c0,0,0,0,0,0c3.5-5.1,6.4-10.2,8.6-15c5.9-12.9,6.3-23,1-28.2l-74.6-74.6c0,0,0,0,0,0
+				c0,0,0,0,0,0l-45.7-45.7c0,0,0,0,0,0c0,0,0,0,0,0l-74.6-74.6c-2.5-2.5-6-3.7-10.4-3.7c-9.6,0-22.8,5.9-36.6,15.9
+				c3-4.1,5.6-8.2,7.9-12.2c0,0,0,0,0,0c13.2-21.5,9.8-41.3,4.6-54.1c-5.6-13.8-14.2-22.6-14.6-22.9c-3.1-3.1-7.5-4.7-13.1-4.7
+				c-17.4,0-44,15-68.9,38.7l-22.7-22.7c-1.1-1.1-2.7-1.8-4.3-1.8c-1.6,0-3.1,0.6-4.3,1.8c-1.1,1.1-1.8,2.7-1.8,4.3
+				c0,1.6,0.6,3.1,1.8,4.3l22.7,22.7c-14.4,15.2-25.9,31.3-32.6,45.9c-1.4,3.1-2.6,6.1-3.5,8.9c-4,12.2-3.3,21.7,2.1,27.1
+				c0,0,0,0,0,0c0,0,0,0,0,0c0.8,0.8,19.5,19.2,45.9,19.2c10.7,0,21.2-3.1,31.2-9.2c0,0,0,0,0,0c4-2.3,8.1-4.9,12.2-7.9
+				c-4.6,6.4-8.5,12.7-11.2,18.7c-5.9,12.9-6.3,23-1,28.2l74.6,74.6c0,0,0,0,0,0c0,0,0,0,0,0l45.7,45.7c0,0,0,0,0,0c0,0,0,0,0,0
+				l74.6,74.6c2.5,2.5,6,3.7,10.4,3.7c0,0,0,0,0,0c8.7,0,20.5-4.9,32.9-13.3v39.3c0,3.3,2.7,6,6,6c3.3,0,6-2.7,6-6v-48.4
+				c2.5-2.1,4.9-4.2,7.3-6.5l36.3,36.3c1.1,1.1,2.7,1.8,4.3,1.8s3.1-0.6,4.3-1.8c1.1-1.1,1.8-2.7,1.8-4.3c0-1.6-0.6-3.1-1.8-4.3
+				l-36.3-36.3c2.3-2.4,4.4-4.9,6.5-7.4c0,0,0,0,0,0h48.4c3.3,0,6-2.7,6-6S476-435.7,472.7-435.7z M235.7-499.1c0.3,0,0.7,0,1,0
+				c5,0,11-1.6,17.9-4.7c12.3-5.7,26.1-15.7,38.8-28.4c12.7-12.7,22.7-26.4,28.4-38.8c3.4-7.4,4.9-13.8,4.7-18.9l39.2,39.2
+				c7.7,7.7-2.3,34.2-29.4,61.3c-27.1,27.1-53.6,37.1-61.3,29.4L235.7-499.1z M161.1-573.6c0.3,0,0.7,0,1,0
+				c14.3,0,36.5-13,56.6-33.1c12.7-12.7,22.7-26.4,28.4-38.8c3.4-7.4,4.9-13.8,4.7-18.9l68.1,68.1c3.9,3.9,3.3,12.6-1.8,23.7
+				c-5.5,11.9-15.3,25.3-27.6,37.6s-25.7,22.1-37.6,27.6c-11.1,5.1-19.8,5.8-23.7,1.8L161.1-573.6z M282.3-453.4
+				c14,0,36-12.4,56.7-33.1c21.2-21.2,33.7-43.8,33-57.7l68.1,68.1c3.9,3.9,3.3,12.6-1.8,23.7c-5.5,11.9-15.3,25.3-27.6,37.6
+				c-19.1,19.1-40.7,32-53.8,32c-3.3,0-5.9-0.9-7.5-2.5l-68.1-68.1C281.6-453.4,282-453.4,282.3-453.4z M184-641.5
+				c0.5-0.5,1-1,1.4-1.4l16.1,16.1c0.4,0.4,0.6,0.9,0.6,1.4s-0.2,1.1-0.6,1.4c-0.8,0.8-2.1,0.8-2.9,0L182.6-640
+				C183.1-640.5,183.5-641,184-641.5z M88.8-733.8c-0.4-0.4-0.6-0.9-0.6-1.4s0.2-1.1,0.6-1.4c0.4-0.4,0.9-0.6,1.4-0.6
+				s1.1,0.2,1.4,0.6l50.3,50.3c0.4,0.4,0.6,0.9,0.6,1.4c0,0.5-0.2,1.1-0.6,1.4c-0.8,0.8-2.1,0.8-2.9,0L88.8-733.8z M79.7-660.7
+				c6.5-14.2,17.7-29.9,31.8-44.7l24.8,24.8c1.1,1.1,2.7,1.8,4.3,1.8c1.6,0,3.1-0.6,4.3-1.8c1.1-1.1,1.8-2.7,1.8-4.3
+				c0-1.6-0.6-3.1-1.8-4.3L120-714c23.8-22.6,49.9-37.5,66-37.5c0.6,0,1.1,0,1.6,0.1c3.7,0.3,6.6,1.4,8.6,3.4l0,0
+				c11.5,11.5-6,48.4-38.2,80.6c-25,25-53.2,41.7-70.3,41.7c-4.5,0-7.9-1.2-10.2-3.5C72.2-634.5,73-646,79.7-660.7z M149.7-619.8
+				c-0.1,0-0.1,0.1-0.2,0.1c-9.3,5.7-19,8.6-29,8.6c-13.8,0-25.6-5.6-33.4-10.6c0.2,0,0.3,0,0.5,0c18.4,0,47.1-16.8,73.2-42.9
+				c27.1-27.1,43.2-55.9,42.8-73.8c2.1,3.3,4.4,7.4,6.3,12.1c7,17.4,5.6,34.3-4.3,50.3c0,0.1-0.1,0.1-0.1,0.2
+				c-5.8,10.4-14.3,21.3-24.5,31.5C171-634.1,160.1-625.6,149.7-619.8z M156.4-603.9c4.8-10.5,13-22.2,23.4-33.3l16.1,16.1
+				c1.1,1.1,2.7,1.8,4.3,1.8c1.6,0,3.1-0.6,4.3-1.8c1.1-1.1,1.8-2.7,1.8-4.3c0-1.6-0.6-3.1-1.8-4.3l-16.1-16.1
+				c18-16.8,37.4-27.8,49.4-27.8c2.4,0,4.4,0.5,5.9,1.3l0,0c0.3,0.2,0.6,0.3,0.8,0.5c0,0,0,0,0,0c0.3,0.2,0.5,0.4,0.8,0.7
+				c0.2,0.2,0.5,0.5,0.7,0.8c0.2,0.3,0.4,0.5,0.6,0.8c2.5,4.4,1.5,12.3-3,22.1c-5.5,11.9-15.3,25.3-27.6,37.6
+				c-19.1,19.1-40.7,32-53.8,32c-2.4,0-4.4-0.5-5.9-1.3l0,0c-0.3-0.2-0.6-0.3-0.8-0.5c0,0,0,0,0,0c-0.3-0.2-0.5-0.4-0.8-0.6
+				c0,0,0,0,0,0c-0.2-0.2-0.5-0.5-0.7-0.8c-0.2-0.3-0.4-0.5-0.6-0.8C150.9-586.2,151.9-594.1,156.4-603.9z M397.9-352.8
+				c0,1.1-0.9,2-2,2s-2-0.9-2-2v-42.1c0,0,0,0,0,0c1.4-1,2.7-2,4.1-3.1c0,0,0,0,0,0V-352.8z M399.9-399.6
+				C399.9-399.6,399.9-399.6,399.9-399.6C399.9-399.6,399.9-399.6,399.9-399.6C399.9-399.6,399.9-399.6,399.9-399.6z M451.3-377.1
+				c0.4,0.4,0.6,0.9,0.6,1.4s-0.2,1.1-0.6,1.4c-0.8,0.8-2.1,0.8-2.9,0l-36.3-36.3c0,0,0,0,0,0c0.5-0.5,1-0.9,1.4-1.4s0.9-1,1.4-1.4
+				L451.3-377.1z M425.9-425.6C425.9-425.6,425.9-425.6,425.9-425.6C425.9-425.6,425.9-425.6,425.9-425.6
+				C425.9-425.6,425.9-425.6,425.9-425.6z M472.7-427.6h-45.2c0,0,0,0,0,0c1.1-1.4,2.1-2.7,3.1-4.1h42.1c1.1,0,2,0.9,2,2
+				S473.8-427.6,472.7-427.6z"/>
+		</g>
+		<path fill="#A9E1E8" d="M580-612.1c-0.3-0.6-0.8-1-1.5-1.1c-0.6-0.1-1.3,0.1-1.8,0.6l-9,9l-6.1-0.2l-0.2-6.1l9-9
+			c0.5-0.5,0.7-1.1,0.6-1.8s-0.5-1.2-1.1-1.5c-2.6-1.2-5.6-1.8-8.5-1.8c-5.5,0-10.6,2.1-14.5,6c-5.1,5.1-7.1,12.4-5.4,19.5
+			c0.4,1.4-0.1,3-1.2,4.1l-36.4,36.4c-3.3,3.3-3.5,8.7-0.4,12c1.6,1.7,3.9,2.7,6.2,2.7c2.3,0,4.4-0.9,6-2.5l36.6-36.6
+			c1.1-1.1,2.7-1.6,4.1-1.2c1.6,0.4,3.3,0.6,5,0.6h0c5.5,0,10.6-2.1,14.5-6C581.9-595.1,583.5-604.3,580-612.1z M561.3-620.1
+			c1.3,0,2.7,0.2,4,0.5l-7.4,7.4c-0.4,0.4-0.6,0.9-0.6,1.5l0.1,3.7l-8-8c0.1-0.1,0.2-0.2,0.2-0.3
+			C552.8-618.4,556.9-620.1,561.3-620.1z M573-591.9c-3.1,3.1-7.2,4.8-11.6,4.8c-1.4,0-2.7-0.2-4-0.5c-2.8-0.7-5.8,0.2-7.9,2.3
+			l-36.6,36.6c-0.8,0.8-2,1.3-3.2,1.3c-1.3,0-2.4-0.5-3.3-1.4c-1.6-1.8-1.5-4.6,0.3-6.5l36.4-36.4c2.1-2.1,3-5.1,2.3-7.9
+			c-1.1-4.2-0.4-8.6,1.7-12.2l11.3,11.3c0.3,0.3,0.8,0.6,1.3,0.6l8.8,0.4c0.6,0,1.1-0.2,1.5-0.6l7.4-7.4
+			C578.7-602,577.2-596,573-591.9z"/>
+		<path fill="#A9E1E8" d="M574.3-418.2l-35.9-35.9c-0.8-0.8-2-0.8-2.8,0l-1,1l-18.5-18.5l-3.5-7.8c-0.2-0.5-0.6-0.8-1-1l-8.1-3.6
+			c-0.8-0.3-1.6-0.2-2.2,0.4l-4.5,4.5c-0.6,0.6-0.8,1.5-0.4,2.2l3.6,8.1c0.2,0.5,0.6,0.8,1,1l7.9,3.5l18.5,18.5l-1,1
+			c-0.4,0.4-0.6,0.9-0.6,1.4s0.2,1,0.6,1.4l35.9,35.9c1.6,1.6,3.8,2.5,6.1,2.5c2.3,0,4.5-0.9,6.1-2.5
+			C577.7-409.4,577.7-414.9,574.3-418.2z M511.3-467.4c-0.2-0.2-0.5-0.4-0.9-0.5l-7.2-3.2l-2.7-6.2l2.6-2.6l6.2,2.7l3.2,7.1
+			c0.1,0.3,0.3,0.6,0.5,0.9l18.8,18.8l-1.6,1.6L511.3-467.4z M571.5-408.9c-0.9,0.9-2,1.3-3.3,1.3s-2.4-0.5-3.3-1.3l-34.5-34.5
+			l6.5-6.5l34.5,34.5C573.3-413.6,573.3-410.7,571.5-408.9z"/>
+		<g>
+			<path fill="#FFFFFF" d="M299.3-772.3c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C301.5-773.1,300.5-772.3,299.3-772.3z M294.4-783.8c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C298.2-786.5,296.5-784.9,294.4-783.8z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M690.1-732.6c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C692.3-733.4,691.2-732.6,690.1-732.6z M685.2-744.1c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C688.9-746.9,687.3-745.2,685.2-744.1z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M875.8-713.8c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5s0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C878-714.6,877-713.8,875.8-713.8z M870.9-725.2c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C874.7-728,873-726.4,870.9-725.2z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M940.9-422.2c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5s-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C943.1-423,942.1-422.2,940.9-422.2z M936.1-433.7c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C939.8-436.5,938.2-434.8,936.1-433.7z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M819.5-218.5c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C821.7-219.3,820.7-218.5,819.5-218.5z M814.6-230c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C818.4-232.7,816.8-231.1,814.6-230z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M492.6-277.8c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C494.8-278.6,493.8-277.8,492.6-277.8z M487.7-289.3c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C491.5-292,489.8-290.4,487.7-289.3z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M263-209.1c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C265.2-209.9,264.2-209.1,263-209.1z M258.1-220.5c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C261.9-223.3,260.3-221.7,258.1-220.5z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M65.4-504.7c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5s-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C67.6-505.5,66.6-504.7,65.4-504.7z M60.5-516.2c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C64.3-519,62.6-517.3,60.5-516.2z"/>
+		</g>
+	</g>
+	<g>
+		<g>
+			<path fill="#A9E1E8" d="M732.1,219.8c0.9,2.7,1.6,5.7,2,8.9c0.4,3.2,3.2,5.7,6.4,5.7c0.3,0,0.5,0,0.8-0.1
+				c1.7-0.2,3.3-1.1,4.3-2.5c1.1-1.4,1.5-3.1,1.3-4.8c-0.5-4.1-1.4-8-2.6-11.5c-0.9-2.6-3.4-4.4-6.2-4.4c-0.7,0-1.4,0.1-2.1,0.3
+				C732.8,212.7,731,216.4,732.1,219.8z M737.5,215.3c0.3-0.1,0.5-0.1,0.8-0.1c1.1,0,2,0.7,2.4,1.7c1.1,3.3,1.9,6.9,2.4,10.7
+				c0.1,0.7-0.1,1.3-0.5,1.8c-0.4,0.5-1,0.9-1.7,0.9c-1.4,0.2-2.6-0.8-2.8-2.2c-0.4-3.5-1.2-6.8-2.2-9.7
+				C735.5,217.2,736.2,215.8,737.5,215.3z"/>
+			<path fill="#A9E1E8" d="M685.3,201.4c0.5,0,1.1-0.1,1.6-0.2c0.2-0.1,5.8-1.4,13.1-1.4c7.8,0,18.7,1.6,25.9,9.3c1.2,1.3,3,2,4.7,2
+				c1.7,0,3.2-0.6,4.4-1.8c1.3-1.2,2-2.8,2-4.5c0.1-1.7-0.6-3.4-1.8-4.7c-10.4-11.1-25-13.4-35.4-13.4c-8.9,0-15.5,1.6-16.3,1.8
+				c-1.7,0.4-3.1,1.5-4,3c-0.9,1.5-1.1,3.2-0.7,4.9C679.7,199.4,682.3,201.4,685.3,201.4z M683.2,193.6c0.3-0.6,0.9-1,1.5-1.1
+				c0.3-0.1,6.7-1.7,15.3-1.7c9.6,0,23.1,2.1,32.5,12.2c0.5,0.5,0.7,1.1,0.7,1.8c0,0.7-0.3,1.3-0.8,1.7c-1,0.9-2.6,0.9-3.5-0.1
+				c-8.2-8.7-20.2-10.6-28.8-10.6c-7.8,0-13.8,1.5-14.1,1.5c-1.3,0.3-2.7-0.5-3-1.8C682.7,194.9,682.8,194.2,683.2,193.6z"/>
+			<path fill="#A9E1E8" d="M730.2,288h-43.5c-5.3,0-9.6,4.3-9.6,9.6v72.5c0,5.3,4.3,9.6,9.6,9.6h43.5c5.3,0,9.6-4.3,9.6-9.6v-72.5
+				C739.9,292.3,735.6,288,730.2,288z M735.9,370.1c0,3.1-2.5,5.6-5.6,5.6h-43.5c-3.1,0-5.6-2.5-5.6-5.6v-72.5
+				c0-3.1,2.5-5.6,5.6-5.6h43.5c3.1,0,5.6,2.5,5.6,5.6V370.1z"/>
+			<path fill="#A9E1E8" d="M727.1,294.1c-3.9,0-7,3.2-7,7s3.2,7,7,7c3.9,0,7-3.2,7-7S731,294.1,727.1,294.1z M727.1,304.2
+				c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S728.8,304.2,727.1,304.2z"/>
+			<path fill="#A9E1E8" d="M727.1,316c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7c3.9,0,7-3.2,7-7C734.1,319.1,731,316,727.1,316z
+				 M727.1,326.1c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S728.8,326.1,727.1,326.1z"/>
+			<path fill="#A9E1E8" d="M727.1,337.9c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7c3.9,0,7-3.2,7-7C734.1,341,731,337.9,727.1,337.9z
+				 M727.1,347.9c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S728.8,347.9,727.1,347.9z"/>
+			<path fill="#A9E1E8" d="M727.1,359.8c-3.9,0-7,3.2-7,7s3.2,7,7,7c3.9,0,7-3.2,7-7S731,359.8,727.1,359.8z M727.1,369.8
+				c-1.7,0-3-1.4-3-3s1.4-3,3-3s3,1.4,3,3S728.8,369.8,727.1,369.8z"/>
+			<path fill="#A9E1E8" d="M710.8,294.1h-20.5c-3.9,0-7,3.2-7,7s3.2,7,7,7h20.5c3.9,0,7-3.2,7-7S714.7,294.1,710.8,294.1z
+				 M710.8,304.2h-20.5c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3S712.5,304.2,710.8,304.2z"/>
+			<path fill="#A9E1E8" d="M710.8,316h-20.5c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7h20.5c3.9,0,7-3.2,7-7
+				C717.9,319.1,714.7,316,710.8,316z M710.8,326.1h-20.5c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3S712.5,326.1,710.8,326.1
+				z"/>
+			<path fill="#A9E1E8" d="M710.8,337.9h-20.5c-3.9,0-7,3.2-7,7c0,3.9,3.2,7,7,7h20.5c3.9,0,7-3.2,7-7
+				C717.9,341,714.7,337.9,710.8,337.9z M710.8,347.9h-20.5c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3
+				S712.5,347.9,710.8,347.9z"/>
+			<path fill="#A9E1E8" d="M710.8,359.8h-20.5c-3.9,0-7,3.2-7,7s3.2,7,7,7h20.5c3.9,0,7-3.2,7-7S714.7,359.8,710.8,359.8z
+				 M710.8,369.8h-20.5c-1.7,0-3-1.4-3-3s1.4-3,3-3h20.5c1.7,0,3,1.4,3,3S712.5,369.8,710.8,369.8z"/>
+			<path fill="#A9E1E8" d="M851.3,206.1h-57.3c-1.8-4.4-6.1-7.5-11.1-7.5h-0.3c-4.2-22.5-23.9-39.6-47.6-39.6h-21.1
+				c-23.7,0-43.4,17.1-47.6,39.6h-0.3c-6.6,0-12,5.4-12,12v13.2c0,6.6,5.4,12,12,12h2.2c3.9,11,11.8,20.2,21.8,25.9
+				c0.1-0.2,0.3-0.3,0.5-0.5c-1.1,1-1.9,2.3-2.1,3.8c-8.9,2.4-16.2,8.6-20,16.8c0-0.1,0.1-0.1,0.1-0.2l-45.1,45.1l-8.2-8.2l-9.9-9.9
+				l-7.2-7.2c-4.3-4.3-10-6.6-16-6.6h0c-6,0-11.7,2.4-16,6.6c-8.8,8.8-8.8,23.2,0,32l23.1,23.1L606,373c0,0,0,0,0,0l1.4,1.4l0,0
+				c0,0,0,0,0.1,0.1c2.8,2.8,6.2,4.8,10,5.8c0.5,0.1,1.1,0.3,1.6,0.4c1.5,0.3,2.9,0.4,4.5,0.4c5.7,0,11.1-2.1,15.3-6
+				c0.3-0.1,0.6-0.3,0.9-0.5l1.9-1.9c0,0,0,0,0,0l24.1-24.1v38.7l-25.2,25.2l-9.9,9.9l-7.3,7.3c0,0,0,0,0,0l-4.7,4.7
+				c-3,3-5.3,6.7-6.6,10.8c-1.3,3.2-2,6.7-2,10.2v7.2v20.7v6.4c-0.8,0.1-1.7,0.2-2.5,0.3c-0.2,0-0.4,0.1-0.6,0.1
+				c-0.8,0.1-1.5,0.3-2.3,0.4c-0.1,0-0.2,0-0.3,0c0,0-0.1,0-0.1,0c-13.8,3.2-24.8,14.3-27.9,28.2c0,0.1-0.1,0.2-0.1,0.4
+				c-0.5,2.5-0.8,5.1-0.8,7.7c0,1.1,0.9,2,2,2h56.5h28.1c1.1,0,2-0.9,2-2v-1.2v-60.1l4.8-4.8l9.9-9.9l25.4-25.4h26.6v19.4v14v10.3
+				v6.7v0c0,1.6,0.1,3.2,0.4,4.8c0.5,2.6,1.3,5.1,2.5,7.5c1.4,3.2,3.3,6.1,5.8,8.6l19.7,19.7l0,0l4.5,4.5c-0.5,0.6-1.1,1.3-1.6,2
+				c-0.1,0.2-0.3,0.3-0.4,0.5c-0.5,0.6-0.9,1.2-1.3,1.9c0,0.1-0.1,0.1-0.1,0.2c0,0,0,0.1-0.1,0.1c-7.5,12.1-7.4,27.6,0.2,39.7
+				c0.1,0.1,0.1,0.2,0.2,0.3c1.4,2.1,3,4.2,4.9,6.1c0.4,0.4,0.9,0.6,1.4,0.6s1-0.2,1.4-0.6l59.8-59.8c0.1-0.1,0.2-0.2,0.3-0.3
+				c0-0.1,0.1-0.1,0.1-0.2c0,0,0-0.1,0.1-0.1c0-0.1,0.1-0.2,0.1-0.3c0,0,0-0.1,0-0.1c0.1-0.3,0.1-0.5,0-0.8c0,0,0-0.1,0-0.1
+				c0-0.1,0-0.2-0.1-0.3c0,0,0-0.1-0.1-0.1c0-0.1-0.1-0.2-0.1-0.2c-0.1-0.1-0.2-0.2-0.3-0.3l-0.8-0.8l-4.5-4.5c0,0,0,0,0,0s0,0,0,0
+				l-38.1-38.1v-6.8v-14v-21.4c0.6,0,1.2,0.1,1.8,0.1c5.8,0,11.6-2.2,16-6.6l2.2-2.2l18.9-18.9l18.6-18.6c0,0,0,0,0,0l1.4-1.4
+				c0,0,0,0,0.1-0.1c4.3-4.3,6.6-10,6.6-16c0-5.7-2.1-11.1-6-15.3c-0.1-0.3-0.3-0.6-0.5-0.9l-1.9-1.9l0,0l-39.1-39.1v-3.7h26.4
+				c0.1,0,0.2,0,0.3,0c0.1,0,0.2,0,0.3,0c10.7,0,19.4-8.7,19.4-19.4s-8.7-19.4-19.4-19.4h-46.1c-3.1,0-5.7-2.5-5.7-5.7
+				s2.5-5.7,5.7-5.7h69.2c0.6,0,1.1-0.1,1.7-0.3c10.3-1.6,18-10.6,18-21C872.6,215.6,863.1,206.1,851.3,206.1z M795,223.8v-5.7h56.4
+				c5.1,0,9.3,4.2,9.3,9.3s-4.2,9.3-9.3,9.3h-67.7c-1.2,0-2.3,0.1-3.4,0.3c0,0,0,0.1-0.1,0.1c0.2-0.4,0.4-0.9,0.5-1.3h2.2
+				C789.6,235.8,795,230.4,795,223.8z M783,202.6c4.4,0,8,3.6,8,8v13.2c0,4.4-3.6,8-8,8h-2.9c-4.4,0-8-3.6-8-8v-13.2
+				c0-4.4,3.6-8,8-8H783z M679.4,179.7c-1.3,1.6-2.5,3.4-3.6,5.2C676.9,183.1,678.1,181.4,679.4,179.7z M666.2,231.8
+				c-4.4,0-8-3.6-8-8v-13.2c0-4.3,3.4-7.8,7.7-8c-0.2,1.6-0.2,3.2-0.2,4.8v12.1c0,4.3,0.6,8.5,1.6,12.4c0-0.1,0-0.1-0.1-0.2H666.2z
+				 M666.2,200.5c0,0.1,0,0.3-0.1,0.4C666.1,200.8,666.1,200.7,666.2,200.5z M667.8,233.7C667.8,233.7,667.8,233.8,667.8,233.7
+				C667.8,233.8,667.8,233.7,667.8,233.7z M669.7,207.4c0-8.2,2.2-15.9,6.1-22.5c11-3.5,22.2-5.3,33.2-5.3c14.1,0,28.4,2.9,42.5,8.7
+				v50.3c-14.1,5.7-28.4,8.7-42.5,8.7c-11,0-22.2-1.8-33.2-5.3c0.5,0.9,1.1,1.8,1.7,2.7c-4.9-7.1-7.8-15.8-7.8-25.1V207.4z
+				 M677.5,244.7c0.6,0.9,1.2,1.7,1.9,2.5C678.7,246.4,678.1,245.5,677.5,244.7z M679.4,247.2c9.9,2.7,19.8,4.1,29.6,4.1h0
+				c15,0,30.2-3.2,45.2-9.5c0.7-0.3,1.2-1,1.2-1.8v-53c0-0.8-0.5-1.5-1.2-1.8c-15-6.3-30.2-9.5-45.2-9.5c-9.8,0-19.7,1.4-29.6,4.1
+				c8.1-10.2,20.7-16.7,34.7-16.7h21.1c21.5,0,39.5,15.4,43.5,35.7h0c-5.9,0.7-10.6,5.8-10.6,11.9v13.2c0,5.4,3.6,10,8.6,11.5
+				c-4.1,10.7-12.2,19.4-22.4,24.4H695C688.9,256.7,683.5,252.4,679.4,247.2z M783.7,271.9h46.1c4.1,0,7.4,3.3,7.4,7.4
+				s-3.3,7.4-7.4,7.4c-0.1,0-0.2,0-0.3,0c-0.1,0-0.2,0-0.3,0h-29c-3.7-6.9-11-11.5-19.3-11.5h-4.5c0.1,0.1,0.1,0.2,0.2,0.2
+				c-4.1-5-9.6-8.7-16-10.4c-0.2-1.5-1-2.9-2.1-3.8c0.2,0.1,0.3,0.3,0.5,0.5c2.8-1.6,5.4-3.5,7.9-5.6c-0.2,0.2-0.4,0.4-0.6,0.5
+				C767.3,265.2,774.7,271.9,783.7,271.9z M767.9,255.1c0.3-0.2,0.5-0.5,0.7-0.7C768.4,254.6,768.1,254.9,767.9,255.1z M798.8,297.2
+				v1.3l-19.3-19.3h1.3C790.7,279.2,798.8,287.3,798.8,297.2z M694.9,263.6h59.4c1.3,0,2.3,1,2.3,2.3s-1,2.3-2.3,2.3h-59.4
+				c-1.3,0-2.3-1-2.3-2.3S693.6,263.6,694.9,263.6z M692.8,260c0.3-0.1,0.6-0.2,0.9-0.3C693.4,259.8,693.1,259.9,692.8,260z
+				 M693.9,259.7c0.3-0.1,0.7-0.1,1.1-0.1C694.6,259.6,694.2,259.6,693.9,259.7z M755.5,259.7c0.3,0.1,0.6,0.2,0.9,0.3
+				C756.1,259.9,755.8,259.8,755.5,259.7z M754.3,259.6c0.4,0,0.7,0,1.1,0.1C755,259.6,754.6,259.6,754.3,259.6z M758.3,261.1
+				c-0.2-0.2-0.4-0.3-0.7-0.5C757.9,260.7,758.1,260.9,758.3,261.1z M757.5,260.5c-0.3-0.2-0.5-0.3-0.8-0.4
+				C756.9,260.2,757.2,260.3,757.5,260.5z M691.5,260.6c-0.2,0.2-0.5,0.3-0.7,0.5C691.1,260.9,691.3,260.7,691.5,260.6z
+				 M692.5,260.1c-0.3,0.1-0.6,0.3-0.8,0.4C692,260.3,692.3,260.2,692.5,260.1z M666.1,289.9c-0.3,1.7-0.4,3.4-0.4,5.2v37.6
+				l-21.2-21.2L666.1,289.9z M569.1,304.1c3.5-3.5,8.2-5.5,13.2-5.5c5,0,9.7,1.9,13.2,5.5l5.4,5.4l-32.8,19.8
+				C561.9,322,562.2,311,569.1,304.1z M570.9,332.3l32.9-19.9l7.6,7.6l-21,31.7L570.9,332.3z M637.5,371.2c-0.2,0-0.3,0.1-0.4,0.2
+				c-0.1,0.1-0.3,0.2-0.4,0.3c-3.5,3.5-8.2,5.5-13.2,5.5c-1.9,0-3.7-0.3-5.5-0.8c-0.4-0.1-0.7-0.2-1.1-0.4c-2.5-0.9-4.8-2.4-6.7-4.4
+				l-0.3-0.3c3.2-4.5,8.4-7.2,13.9-7.2c5.5,0,10.5,2.6,13.7,6.9L637.5,371.2z M640.5,368.2c-4-5.1-10-8.1-16.6-8.1
+				c-6.6,0-12.8,3.1-16.8,8.3l-13.8-13.8l21-31.7l7.9,7.9c0.8,0.8,2,0.8,2.8,0l6.7-6.7l26.4,26.4L640.5,368.2z M661,347.7
+				l-26.4-26.4l7.1-7.1l24,24v4.7L661,347.7z M613.9,455.5c0-3,0.6-5.9,1.7-8.7c0,0,0-0.1,0.1-0.1c1.1-3.5,3-6.6,5.6-9.2l3-3
+				c1.5,2.7,2.4,5.7,2.4,8.8c0,7.9-5.3,14.8-12.8,17V455.5z M579.4,524.8c0.1-1.2,0.2-2.3,0.4-3.5h46.7l-3.4-4h-42.4
+				c3.3-11,12.2-19.6,23.3-22.6l25.5,30.1H579.4z M634.8,524.8l-26.2-31c0,0,0.1,0,0.1,0c0.4,0,0.7-0.1,1.1-0.1c0.2,0,0.4,0,0.6-0.1
+				c0.6,0,1.1-0.1,1.7-0.1c1.1,0,2-0.9,2-2v-4l43.9,37.2H634.8z M660.5,463.2c-0.4,0.4-0.6,0.9-0.6,1.4v52.7h-4.7l-41.3-35v-18.1
+				c9.7-2.3,16.8-11.1,16.8-21.1c0-4.2-1.2-8.2-3.4-11.7l4.7-4.7l32.5,32.5L660.5,463.2z M667.3,456.5l-32.5-32.5l7.1-7.1l32.5,32.5
+				L667.3,456.5z M677.2,446.6L644.7,414l23.8-23.8H684l16.7,32.8L677.2,446.6z M730.6,421.4h-26.2l-15.9-31.2h42.1V421.4z
+				 M745.5,497.2l-3.3-3.3c-2.1-2.1-3.8-4.6-5-7.4c0,0,0-0.1-0.1-0.1c-1.7-3.3-2.5-6.8-2.5-10.5v-4.3c3,0.8,5.7,2.3,7.9,4.6
+				C748.1,481.7,749.2,490.4,745.5,497.2z M762.9,528.6l29.5,2.5l-30,30C757,551,757.2,538.6,762.9,528.6z M766.8,567.3
+				c-0.8-0.9-1.5-1.8-2.2-2.7l33.1-33.1l4.5,0.4L766.8,567.3z M805.9,528.1l-40.4-3.4c0,0,0.1-0.1,0.1-0.1c0.2-0.3,0.4-0.5,0.6-0.8
+				c0.1-0.2,0.3-0.3,0.4-0.5c0.4-0.4,0.7-0.8,1.1-1.2c0.1-0.1,0.2-0.2,0.2-0.3c0.5-0.8,0.4-1.8-0.3-2.5l-2.8-2.8l45.8-3.8l6.2-0.5
+				l5.4-0.4L805.9,528.1z M818.4,505.1l-3.3,3.3l-53.9,4.5l-12.8-12.8c5.2-8.4,4-19.7-3.1-26.8c-3-3-6.6-5-10.7-5.8v-6.6h46v5.6
+				c0,0.5,0.2,1,0.6,1.4L818.4,505.1z M770.4,416.9c2.9,2.9,6.4,4.8,10.2,5.8v20.1h-46v-19.4v-33.2h31.9c-1.8,3.3-2.7,6.9-2.7,10.7
+				C763.8,407,766.2,412.6,770.4,416.9z M780.6,446.8v10h-46v-10H780.6z M799.6,414.1c-7.3,7.3-19.1,7.3-26.4,0s-7.3-19.1,0-26.4
+				l5.5-5.5l21.8,30.9L799.6,414.1z M803.5,410.2l-21.8-30.9l7.5-7.5l29.9,22.8L803.5,410.2z M783.5,371.8v-24.5l5.5,5.5l6.7,6.7
+				L783.5,371.8z M803.5,377.8l12.5-12.5l7.9,7.9l-11.4,11.4L803.5,377.8z M840.2,345.6l0.1,0.1c0.1,0.3,0.3,0.6,0.5,0.8
+				c3.5,3.5,5.5,8.2,5.5,13.2c0,1.2-0.1,2.5-0.4,3.7c-0.7,3.6-2.5,6.9-5.1,9.5c0,0-0.1,0.1-0.1,0.1l-0.2,0.2
+				c-4.5-3.2-7.2-8.4-7.2-13.9C833.3,353.8,835.8,348.8,840.2,345.6z M837.4,342.7c-5.1,4-8.1,10-8.1,16.6c0,6.6,3.1,12.8,8.3,16.8
+				l-15.7,15.7l-6.2-4.7l12.4-12.4c0.8-0.8,0.8-2,0-2.8l-10.8-10.8c-0.8-0.8-2.1-0.8-2.8,0l-14.3,14.3L792,369l8-8
+				c0.8-0.8,0.8-2,0-2.8l-6.7-6.7l26.4-26.4L837.4,342.7z M816.9,322.2l-26.4,26.4l-7-7l-0.1-0.1l26.4-26.4L816.9,322.2z M807,312.3
+				l-26.4,26.4l-1.1-1.1l-30.2-30.2c-0.8-0.8-2-0.8-2.8,0s-0.8,2,0,2.8l32.7,32.7l0.4,0.4v32.5l-9.1,9.1c-0.4,0.4-0.8,0.9-1.2,1.3
+				h-99.6V295c0-12.4,8.3-22.8,19.7-26.1c1.1,2,3.2,3.3,5.6,3.3h59.4c2.4,0,4.5-1.3,5.6-3.3c6.5,1.8,12,6.1,15.5,11.6l0,0
+				c0.1,0.1,0.2,0.3,0.3,0.4L807,312.3z M853.9,244.4c-0.1,0-0.2,0-0.4,0.1c-0.2,0.1-0.5,0.1-0.6,0.1h-69.2c-5.3,0-9.7,4.3-9.7,9.7
+				s4.3,9.7,9.7,9.7h46.1c8.5,0,15.4,6.9,15.4,15.4c0,8.5-6.9,15.4-15.3,15.4c-0.1,0-0.1,0-0.2,0c-0.1,0-0.2,0-0.3,0
+				c-0.1,0-0.1,0-0.2,0h-26.5c-0.2-1.4-0.4-2.7-0.8-4h27.3c0.1,0,0.1,0,0.2,0c0.1,0,0.2,0,0.3,0c0.1,0,0.1,0,0.2,0
+				c6.3,0,11.3-5.1,11.3-11.4c0-6.3-5.1-11.4-11.4-11.4h-46.1c-7.5,0-13.7-6.1-13.7-13.7c0-0.4,0-0.9,0.1-1.3
+				c-0.1,0.1-0.3,0.2-0.4,0.4c3.3-3.4,6.1-7.3,8.4-11.5c1.7-0.8,3.6-1.2,5.6-1.2h67.7c7.3,0,13.3-6,13.3-13.3
+				c0-7.3-6-13.3-13.3-13.3H795v-3.5c0-0.2,0-0.3,0-0.5h56.4c9.5,0,17.3,7.7,17.3,17.3C868.6,235.8,862.3,243.2,853.9,244.4z"/>
+			<path fill="#A9E1E8" d="M587,328.5c-3.8,0-6.8,3.1-6.8,6.8s3.1,6.8,6.8,6.8s6.8-3.1,6.8-6.8S590.8,328.5,587,328.5z M587,338.1
+				c-1.6,0-2.8-1.3-2.8-2.8s1.3-2.8,2.8-2.8s2.8,1.3,2.8,2.8S588.6,338.1,587,338.1z"/>
+			<g>
+				<path fill="#A9E1E8" d="M819.5,350.3c-4.4,0-8-3.6-8-8c0-4.4,3.6-8,8-8c4.4,0,8,3.6,8,8C827.5,346.7,823.9,350.3,819.5,350.3z
+					 M819.5,338.3c-2.2,0-4,1.8-4,4c0,2.2,1.8,4,4,4c2.2,0,4-1.8,4-4C823.5,340.1,821.7,338.3,819.5,338.3z"/>
+			</g>
+			<g>
+				<path fill="#A9E1E8" d="M638,523.6c-3.5,0-6.3-2.8-6.3-6.3s2.8-6.3,6.3-6.3s6.3,2.8,6.3,6.3S641.5,523.6,638,523.6z M638,514.9
+					c-1.3,0-2.3,1-2.3,2.3c0,1.3,1,2.3,2.3,2.3s2.3-1,2.3-2.3C640.3,516,639.3,514.9,638,514.9z"/>
+			</g>
+			<g>
+				<path fill="#A9E1E8" d="M802.6,526.4c-1.7,0-3.3-0.7-4.5-1.9c-2.5-2.5-2.5-6.5,0-8.9c1.2-1.2,2.8-1.9,4.5-1.9s3.3,0.7,4.5,1.9
+					c1.2,1.2,1.9,2.8,1.9,4.5s-0.7,3.3-1.9,4.5C805.8,525.8,804.2,526.4,802.6,526.4z M802.6,517.8c-0.6,0-1.2,0.2-1.6,0.7
+					c-0.9,0.9-0.9,2.4,0,3.3c0.9,0.9,2.4,0.9,3.3,0c0.4-0.4,0.7-1,0.7-1.6c0-0.6-0.2-1.2-0.7-1.6C803.8,518,803.2,517.8,802.6,517.8
+					z"/>
+			</g>
+		</g>
+		<g>
+			<path fill="#A9E1E8" d="M613.3,102.4l-46-46l0.1-0.1c1.1-1.1,1.6-2.5,1.6-4s-0.6-2.9-1.6-4l-0.6-0.6c-1.1-1.1-2.5-1.6-4-1.6
+				s-2.9,0.6-4,1.6l-0.1,0.1l-46-46c-0.8-0.8-2-0.8-2.8,0L318,193.8c-0.8,0.8-0.8,2,0,2.8l46,46l2.8-2.8l-44.6-44.6l61.1-61.1
+				l44.6,44.6l-77,76.9l2.8,2.8L561.7,50.6c0.3-0.3,0.7-0.5,1.1-0.5s0.8,0.2,1.1,0.5l0.6,0.6c0.3,0.3,0.5,0.7,0.5,1.1
+				s-0.2,0.8-0.5,1.1L356.7,261.3l2.8,2.8l13-13l46,46c0.4,0.4,0.9,0.6,1.4,0.6s1-0.2,1.4-0.6l191.9-191.9
+				C614.1,104.5,614.1,103.2,613.3,102.4z M511.3,6.1l44.6,44.6l-61.1,61.1l-44.6-44.6L511.3,6.1z M386.2,131.2l61.1-61.1l44.6,44.6
+				l-61.1,61.1L386.2,131.2z M500.5,123.2l44.6,44.6L483.9,229l-44.6-44.6L500.5,123.2z M420,292.9l-44.6-44.6l61.1-61.1l44.6,44.6
+				L420,292.9z M547.9,165l-44.6-44.6l61.1-61.1l44.6,44.6L547.9,165z"/>
+			<path fill="#A9E1E8" d="M251.2,373.6l12.6-12.6l-2.8-2.8L53.5,565.6c-0.6,0.6-1.7,0.6-2.3,0l-0.6-0.6c-0.6-0.6-0.6-1.7,0-2.3
+				L258,355.4l-2.8-2.8l-13,13l0.4-0.4l-46-46c-0.8-0.8-2-0.8-2.8,0L1.9,511c-0.8,0.8-0.8,2,0,2.8l46,46l2.8-2.8L6.1,512.4
+				l61.1-61.1l44.6,44.6l2.8-2.8l-44.6-44.6l61.1-61.1l44.6,44.6l2.8-2.8l-44.6-44.6l61.1-61.1l44.6,44.6l-192,192
+				c-2.2,2.2-2.2,5.7,0,7.9l0.6,0.6c1.1,1.1,2.5,1.6,4,1.6s2.9-0.6,4-1.6l0.1-0.1l46,46c0.4,0.4,0.9,0.6,1.4,0.6s1-0.2,1.4-0.6
+				l191.9-191.9c0.4-0.4,0.6-0.9,0.6-1.4s-0.2-1-0.6-1.4L251.2,373.6z M184.4,440.4L229,485l-61.1,61.1l-44.6-44.6L184.4,440.4z
+				 M103.9,610.1l-44.6-44.6l61.1-61.1L165,549L103.9,610.1z M231.8,482.2l-44.6-44.6l61.1-61.1l44.6,44.6L231.8,482.2z"/>
+			<path fill="#A9E1E8" d="M474,392.1h-39.3c0,0,0,0,0,0c3.5-5.1,6.4-10.2,8.6-15c5.9-12.9,6.3-23,1-28.2l-74.6-74.6c0,0,0,0,0,0
+				c0,0,0,0,0,0l-45.7-45.7c0,0,0,0,0,0c0,0,0,0,0,0l-74.6-74.6c-2.5-2.5-6-3.7-10.4-3.7c-9.6,0-22.8,5.9-36.6,15.9
+				c3-4.1,5.6-8.2,7.9-12.2c0,0,0,0,0,0c13.2-21.5,9.8-41.3,4.6-54.1c-5.6-13.8-14.2-22.6-14.6-22.9c-3.1-3.1-7.5-4.7-13.1-4.7
+				c-17.4,0-44,15-68.9,38.7L95.8,88.3c-1.1-1.1-2.7-1.8-4.3-1.8c-1.6,0-3.1,0.6-4.3,1.8c-1.1,1.1-1.8,2.7-1.8,4.3
+				c0,1.6,0.6,3.1,1.8,4.3l22.7,22.7c-14.4,15.2-25.9,31.3-32.6,45.9c-1.4,3.1-2.6,6.1-3.5,8.9c-4,12.2-3.3,21.7,2.1,27.1
+				c0,0,0,0,0,0c0,0,0,0,0,0c0.8,0.8,19.5,19.2,45.9,19.2c10.7,0,21.2-3.1,31.2-9.2c0,0,0,0,0,0c4-2.3,8.1-4.9,12.2-7.9
+				c-4.6,6.4-8.5,12.7-11.2,18.7c-5.9,12.9-6.3,23-1,28.2l74.6,74.6c0,0,0,0,0,0c0,0,0,0,0,0l45.7,45.7c0,0,0,0,0,0c0,0,0,0,0,0
+				l74.6,74.6c2.5,2.5,6,3.7,10.4,3.7c0,0,0,0,0,0c8.7,0,20.5-4.9,32.9-13.3v39.3c0,3.3,2.7,6,6,6c3.3,0,6-2.7,6-6v-48.4
+				c2.5-2.1,4.9-4.2,7.3-6.5l36.3,36.3c1.1,1.1,2.7,1.8,4.3,1.8s3.1-0.6,4.3-1.8c1.1-1.1,1.8-2.7,1.8-4.3c0-1.6-0.6-3.1-1.8-4.3
+				l-36.3-36.3c2.3-2.4,4.4-4.9,6.5-7.4c0,0,0,0,0,0H474c3.3,0,6-2.7,6-6S477.3,392.1,474,392.1z M237,328.7c0.3,0,0.7,0,1,0
+				c5,0,11-1.6,17.9-4.7c12.3-5.7,26.1-15.7,38.8-28.4c12.7-12.7,22.7-26.4,28.4-38.8c3.4-7.4,4.9-13.8,4.7-18.9l39.2,39.2
+				c7.7,7.7-2.3,34.2-29.4,61.3c-27.1,27.1-53.6,37.1-61.3,29.4L237,328.7z M162.4,254.1c0.3,0,0.7,0,1,0c14.3,0,36.5-13,56.6-33.1
+				c12.7-12.7,22.7-26.4,28.4-38.8c3.4-7.4,4.9-13.8,4.7-18.9l68.1,68.1c3.9,3.9,3.3,12.6-1.8,23.7c-5.5,11.9-15.3,25.3-27.6,37.6
+				s-25.7,22.1-37.6,27.6c-11.1,5.1-19.8,5.8-23.7,1.8L162.4,254.1z M283.6,374.4c14,0,36-12.4,56.7-33.1
+				c21.2-21.2,33.7-43.8,33-57.7l68.1,68.1c3.9,3.9,3.3,12.6-1.8,23.7c-5.5,11.9-15.3,25.3-27.6,37.6c-19.1,19.1-40.7,32-53.8,32
+				c-3.3,0-5.9-0.9-7.5-2.5l-68.1-68.1C283,374.3,283.3,374.4,283.6,374.4z M185.3,186.3c0.5-0.5,1-1,1.4-1.4l16.1,16.1
+				c0.4,0.4,0.6,0.9,0.6,1.4s-0.2,1.1-0.6,1.4c-0.8,0.8-2.1,0.8-2.9,0l-16.1-16.1C184.4,187.3,184.8,186.8,185.3,186.3z M90.1,94
+				c-0.4-0.4-0.6-0.9-0.6-1.4s0.2-1.1,0.6-1.4c0.4-0.4,0.9-0.6,1.4-0.6s1.1,0.2,1.4,0.6l50.3,50.3c0.4,0.4,0.6,0.9,0.6,1.4
+				c0,0.5-0.2,1.1-0.6,1.4c-0.8,0.8-2.1,0.8-2.9,0L90.1,94z M81,167c6.5-14.2,17.7-29.9,31.8-44.7l24.8,24.8
+				c1.1,1.1,2.7,1.8,4.3,1.8c1.6,0,3.1-0.6,4.3-1.8c1.1-1.1,1.8-2.7,1.8-4.3c0-1.6-0.6-3.1-1.8-4.3l-24.8-24.8
+				c23.8-22.6,49.9-37.5,66-37.5c0.6,0,1.1,0,1.6,0.1c3.7,0.3,6.6,1.4,8.6,3.4l0,0c11.5,11.5-6,48.4-38.2,80.6
+				c-25,25-53.2,41.7-70.3,41.7c-4.5,0-7.9-1.2-10.2-3.5C73.5,193.3,74.3,181.8,81,167z M151,207.9c-0.1,0-0.1,0.1-0.2,0.1
+				c-9.3,5.7-19,8.6-29,8.6c-13.8,0-25.6-5.6-33.4-10.6c0.2,0,0.3,0,0.5,0c18.4,0,47.1-16.8,73.2-42.9
+				c27.1-27.1,43.2-55.9,42.8-73.8c2.1,3.3,4.4,7.4,6.3,12.1c7,17.4,5.6,34.3-4.3,50.3c0,0.1-0.1,0.1-0.1,0.2
+				c-5.8,10.4-14.3,21.3-24.5,31.5C172.3,193.7,161.4,202.1,151,207.9z M157.7,223.9c4.8-10.5,13-22.2,23.4-33.3l16.1,16.1
+				c1.1,1.1,2.7,1.8,4.3,1.8c1.6,0,3.1-0.6,4.3-1.8c1.1-1.1,1.8-2.7,1.8-4.3c0-1.6-0.6-3.1-1.8-4.3l-16.1-16.1
+				c18-16.8,37.4-27.8,49.4-27.8c2.4,0,4.4,0.5,5.9,1.3l0,0c0.3,0.2,0.6,0.3,0.8,0.5c0,0,0,0,0,0c0.3,0.2,0.5,0.4,0.8,0.7
+				c0.2,0.2,0.5,0.5,0.7,0.8c0.2,0.3,0.4,0.5,0.6,0.8c2.5,4.4,1.5,12.3-3,22.1c-5.5,11.9-15.3,25.3-27.6,37.6
+				c-19.1,19.1-40.7,32-53.8,32c-2.4,0-4.4-0.5-5.9-1.3l0,0c-0.3-0.2-0.6-0.3-0.8-0.5c0,0,0,0,0,0c-0.3-0.2-0.5-0.4-0.8-0.6
+				c0,0,0,0,0,0c-0.2-0.2-0.5-0.5-0.7-0.8c-0.2-0.3-0.4-0.5-0.6-0.8C152.2,241.6,153.2,233.7,157.7,223.9z M399.2,474.9
+				c0,1.1-0.9,2-2,2s-2-0.9-2-2v-42.1c0,0,0,0,0,0c1.4-1,2.7-2,4.1-3.1c0,0,0,0,0,0V474.9z M401.2,428.2
+				C401.2,428.2,401.2,428.2,401.2,428.2C401.2,428.2,401.2,428.2,401.2,428.2C401.2,428.2,401.2,428.2,401.2,428.2z M452.6,450.7
+				c0.4,0.4,0.6,0.9,0.6,1.4s-0.2,1.1-0.6,1.4c-0.8,0.8-2.1,0.8-2.9,0l-36.3-36.3c0,0,0,0,0,0c0.5-0.5,1-0.9,1.4-1.4s0.9-1,1.4-1.4
+				L452.6,450.7z M427.2,402.2C427.2,402.2,427.2,402.2,427.2,402.2C427.2,402.2,427.2,402.2,427.2,402.2
+				C427.2,402.2,427.2,402.2,427.2,402.2z M474,400.2h-45.2c0,0,0,0,0,0c1.1-1.4,2.1-2.7,3.1-4.1H474c1.1,0,2,0.9,2,2
+				S475.1,400.2,474,400.2z"/>
+		</g>
+		<path fill="#A9E1E8" d="M581.3,215.7c-0.3-0.6-0.8-1-1.5-1.1c-0.6-0.1-1.3,0.1-1.8,0.6l-9,9l-6.1-0.2l-0.2-6.1l9-9
+			c0.5-0.5,0.7-1.1,0.6-1.8s-0.5-1.2-1.1-1.5c-2.6-1.2-5.6-1.8-8.5-1.8c-5.5,0-10.6,2.1-14.5,6c-5.1,5.1-7.1,12.4-5.4,19.5
+			c0.4,1.4-0.1,3-1.2,4.1l-36.4,36.4c-3.3,3.3-3.5,8.7-0.4,12c1.6,1.7,3.9,2.7,6.2,2.7c2.3,0,4.4-0.9,6-2.5l36.6-36.6
+			c1.1-1.1,2.7-1.6,4.1-1.2c1.6,0.4,3.3,0.6,5,0.6h0c5.5,0,10.6-2.1,14.5-6C583.2,232.7,584.8,223.5,581.3,215.7z M562.7,207.7
+			c1.3,0,2.7,0.2,4,0.5l-7.4,7.4c-0.4,0.4-0.6,0.9-0.6,1.5l0.1,3.7l-8-8c0.1-0.1,0.2-0.2,0.2-0.3
+			C554.1,209.4,558.3,207.7,562.7,207.7z M574.4,235.9c-3.1,3.1-7.2,4.8-11.6,4.8c-1.4,0-2.7-0.2-4-0.5c-2.8-0.7-5.8,0.2-7.9,2.3
+			L514.2,279c-0.8,0.8-2,1.3-3.2,1.3c-1.3,0-2.4-0.5-3.3-1.4c-1.6-1.8-1.5-4.6,0.3-6.5l36.4-36.4c2.1-2.1,3-5.1,2.3-7.9
+			c-1.1-4.2-0.4-8.6,1.7-12.2l11.3,11.3c0.3,0.3,0.8,0.6,1.3,0.6l8.8,0.4c0.6,0,1.1-0.2,1.5-0.6l7.4-7.4
+			C580,225.8,578.5,231.7,574.4,235.9z"/>
+		<path fill="#A9E1E8" d="M575.6,409.6l-35.9-35.9c-0.8-0.8-2-0.8-2.8,0l-1,1l-18.5-18.5l-3.5-7.8c-0.2-0.5-0.6-0.8-1-1l-8.1-3.6
+			c-0.8-0.3-1.6-0.2-2.2,0.4l-4.5,4.5c-0.6,0.6-0.8,1.5-0.4,2.2l3.6,8.1c0.2,0.5,0.6,0.8,1,1l7.9,3.5l18.5,18.5l-1,1
+			c-0.4,0.4-0.6,0.9-0.6,1.4s0.2,1,0.6,1.4l35.9,35.9c1.6,1.6,3.8,2.5,6.1,2.5c2.3,0,4.5-0.9,6.1-2.5
+			C579,418.4,579,412.9,575.6,409.6z M512.6,360.4c-0.2-0.2-0.5-0.4-0.9-0.5l-7.2-3.2l-2.7-6.2l2.6-2.6l6.2,2.7l3.2,7.1
+			c0.1,0.3,0.3,0.6,0.5,0.9l18.8,18.8l-1.6,1.6L512.6,360.4z M572.8,418.9c-0.9,0.9-2,1.3-3.3,1.3s-2.4-0.5-3.3-1.3l-34.5-34.5
+			l6.5-6.5l34.5,34.5C574.6,414.2,574.6,417.1,572.8,418.9z"/>
+		<g>
+			<path fill="#FFFFFF" d="M300.6,55.5c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C302.8,54.6,301.8,55.5,300.6,55.5z M295.7,44c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C299.5,41.2,297.8,42.9,295.7,44z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M691.4,95.1c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C693.6,94.3,692.5,95.1,691.4,95.1z M686.5,83.7c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C690.2,80.9,688.6,82.6,686.5,83.7z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M877.1,114c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5s0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C879.3,113.2,878.3,114,877.1,114z M872.2,102.6c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C876,99.8,874.3,101.4,872.2,102.6z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M942.2,405.5c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5s-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C944.5,404.7,943.4,405.5,942.2,405.5z M937.4,394.1c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C941.1,391.3,939.5,392.9,937.4,394.1z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M820.8,609.3c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C823,608.5,822,609.3,820.8,609.3z M816,597.8c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C819.7,595,818.1,596.7,816,597.8z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M493.9,550c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C496.1,549.1,495.1,550,493.9,550z M489,538.5c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C492.8,535.7,491.1,537.4,489,538.5z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M264.3,618.7c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5c0,1.2-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C266.5,617.9,265.5,618.7,264.3,618.7z M259.5,607.3c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C263.2,604.5,261.6,606.1,259.5,607.3z"/>
+		</g>
+		<g>
+			<path fill="#FFFFFF" d="M66.7,323c-1.2,0-2.2-0.8-2.5-2c-0.9-3.7-3.2-6-6.9-7c-1.2-0.3-2-1.3-2-2.5c0-1.2,0.8-2.2,2-2.5
+				c3.7-0.9,6-3.2,7-6.9c0.3-1.2,1.3-2,2.5-2c1.2,0,2.2,0.8,2.5,2c0.9,3.7,3.2,6,6.9,7c1.2,0.3,2,1.3,2,2.5s-0.8,2.2-2,2.5
+				c-3.7,0.9-6,3.2-7,6.9C68.9,322.2,67.9,323,66.7,323z M61.8,311.6c2.1,1.2,3.7,2.8,4.9,4.9c1.2-2.1,2.8-3.7,4.9-4.9
+				c-2.1-1.2-3.7-2.8-4.9-4.9C65.6,308.8,63.9,310.5,61.8,311.6z"/>
+		</g>
+	</g>
+	<circle fill="#A9E1E8" cx="662.5" cy="-946" r="32.2"/>
+</g>
+</svg>

--- a/curiositymachine/static/errors/maintenance.html
+++ b/curiositymachine/static/errors/maintenance.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Curiosity Machine</title>
+  <link href='//fonts.googleapis.com/css?family=Raleway:400,700,500,300,600' rel='stylesheet' type='text/css'>
+  <style>
+    body {
+      font-family: "Raleway";
+      text-align: center;
+      background-color: #1A3437;
+      color: white;
+    }
+
+    h1 {
+      font-weight: normal;
+      font-size: 2em;
+    }
+
+    p {
+      margin: 4px 0;
+      color: #A9E1E8;
+    }
+
+    a:link,
+    a:visited {
+      color: #ACDCE1;
+      text-decoration: none;
+    }
+    a:hover,
+    a:active {
+      color: #ACDCE1;
+      text-decoration: underline;
+    }
+
+    .container {
+      max-width: 600px;
+      margin: auto;
+      margin-top: 1em;
+    }
+
+    .maintenance-img {
+      max-width: 480px;
+      margin: 1em 0;
+    }
+
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Curiosity Machine is temporarily down for scheduled maintenance.</h1>
+    <p>Right now we're making Curiosity machine better.</p>
+    <p>We're sorry for the inconvenience, but we'll be back up soon.</p>
+    <img class="maintenance-img" src="astronaut.svg" alt="Astronaut fixing a satellite"/>
+    <p>
+      If you think you're seeing this page in error, please contact us at
+      <a href="mailto:curiosity@iridescentlearning.org">curiosity@iridescentlearning.org</a>.
+    </p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Can view locally at e.g. `http://localhost:8000/static/errors/maintenance.html`, and can be installed on Heroku as follows: https://devcenter.heroku.com/articles/error-pages

Because these end up being static pages hosted on s3, keeping the page simple and writing it all in one html file is easiest.

<!---
@huboard:{"custom_state":"archived"}
-->
