### PR TITLE
Added Join modal to Login page

### DIFF
--- a/curiositymachine/templates/registration/login.html
+++ b/curiositymachine/templates/registration/login.html
@@ -23,12 +23,3 @@
   <p><button class="btn btn-primary btn-lg" data-toggle="modal" data-target="#join-modal">Join</button></p>
 
 {% endblock %}
-
-  <!-- global modals -->
-  {% include "profiles/join_modal.html" %}
-  {% include "profiles/student/join_modal.html" with form=join_form %}
-  {% include "profiles/mentor/join_modal.html" with form=mentor_join_form %}
-  {% include "profiles/educator/join_modal.html" with form=educator_join_form %}
-  {% include "profiles/parent/join_modal.html" with form=parent_join_form %}
-  {% include "registration/_login_modal.html" with form=login_form %}
-  <!-- /global modals -->


### PR DESCRIPTION
Added a button that opens the Join modal to the login page, so when we direct people to login they can easily switch into creating an account.

Currently this links to the "old" join modal which opens up the account specific modals (unlike the new homepage.) This could be a good page to flip to the "new" style some time soon; would probably be relatively low effort.

<!---
@huboard:{"custom_state":"archived"}
-->
