### PR TITLE
Band-aid fix for image integrity error, hopefully

### DIFF
--- a/curiositymachine/tasks.py
+++ b/curiositymachine/tasks.py
@@ -3,11 +3,14 @@ import requests
 import tempfile
 import hashlib
 import django_rq
+import datetime
 from django.conf import settings
 from django.db import DatabaseError
 import logging
 
 logger = logging.getLogger(__name__)
+
+WAIT_TIME = datetime.timedelta(seconds=10)
 
 def sum_for_fd(fd):
     md5 = hashlib.md5()
@@ -15,7 +18,7 @@ def sum_for_fd(fd):
         md5.update(chunk)
     return md5.hexdigest()
 
-def upload_to_s3(obj, key_prefix='', queue_after=None): # key_prefix should include the trailing / if necessary
+def upload_to_s3(obj, key_prefix='', queue_after=None, retry=True): # key_prefix should include the trailing / if necessary
     response = requests.get(obj.source_url, stream=True)
     conn = tinys3.Connection(settings.AWS_ACCESS_KEY_ID, settings.AWS_SECRET_ACCESS_KEY, tls=True)
 
@@ -31,11 +34,15 @@ def upload_to_s3(obj, key_prefix='', queue_after=None): # key_prefix should incl
 
     try:
         obj.save(force_update=True)
+        if queue_after:
+            django_rq.enqueue(queue_after, obj)
     except DatabaseError as err:
-        logger.warning("Exception on save, trying again", exc_info=err)
-        # potential race condition where two saves both try to insert, try once more
-        obj.save(force_update=True)
-
-    if queue_after:
-        django_rq.enqueue(queue_after, obj)
+        if retry:
+            # potential race condition where two saves both try to insert, as a band-aid try once more a bit later
+            logger.warning("Exception on save, trying again", exc_info=err)
+            scheduler = django_rq.get_scheduler()
+            scheduler.enqueue_in(WAIT_TIME, upload_to_s3, obj, key_prefix=key_prefix, queue_after=queue_after, retry=False)
+        else:
+            logger.warning("Exception on save, not retrying", exc_info=err)
+            raise
 


### PR DESCRIPTION
Instead of just retrying to save immediately, enqueue the job to rerun after a brief pause. Only do this retry once so we don't have endlessly looping retries though. If this works I think it might be a suitable fix until we get away from the `upload_to_s3` jobs altogether.
