### PR TITLE
Logs info message when unable to send email due to missing address

### DIFF
--- a/cmemails/mailer.py
+++ b/cmemails/mailer.py
@@ -96,6 +96,9 @@ def deliver_email(event_name, profile, **context):
     key = "_".join([user_type, event_name])
     try:
         info = email_info[key]
-        return email([profile.user.email], context.get('subject', info['subject']), context, info['template'], context.get('cc', None))
+        if profile.user.email:
+            return email([profile.user.email], context.get('subject', info['subject']), context, info['template'], context.get('cc', None))
+        else:
+            logger.info("No email address; email not sent for event: {}, type: {}, username: {}".format(event_name, user_type, profile.user.username))
     except KeyError:
         logger.warn("No email defined for event: {}, type: {}, username: {}".format(event_name, user_type, profile.user.username))


### PR DESCRIPTION
This should prevent a bunch of this type of error in Papertrail: 

> Nov 18 18:31:04 curiositymachine app/worker.1: ERROR:rq.worker "smtplib.SMTPRecipientsRefused: {'': (501, b'5.1.3 Bad recipient address syntax')}

<!---
@huboard:{"milestone_order":679.0,"order":679,"custom_state":"archived"}
-->
