### PR TITLE
set welcome in UserJoinView for all request types

### DIFF
--- a/curiositymachine/views/generic.py
+++ b/curiositymachine/views/generic.py
@@ -43,6 +43,7 @@ class UserJoinView(CreateView):
     logged_in_redirect = None
     success_message = None
     template_names = None
+    welcome = None
 
     def get_logged_in_redirect(self):
         return self.logged_in_redirect


### PR DESCRIPTION
:bug: 

Should fix these Papertrail errors: https://iridescentlearning.slack.com/archives/dev-team/p1448862222000005

<!---
@huboard:{"custom_state":"archived","order":689,"milestone_order":689}
-->
