### PR TITLE
Mentor profile page fix

### DIFF
--- a/profiles/templates/mentor_profile.html
+++ b/profiles/templates/mentor_profile.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<h1>{{user.username}}</h1>
-{% include "_mentor_profile_info.html" %}
+<h1>{{mentor.username}}</h1>
+{% include "_mentor_profile_info.html" with profile=mentor_profile %}
 
 {% endblock %}

--- a/profiles/views/mentor.py
+++ b/profiles/views/mentor.py
@@ -112,7 +112,7 @@ def show_profile(request, username):
     user = get_object_or_404(User, username=username)
     profile = get_object_or_404(Profile, user=user, is_mentor=True)
 
-    return render(request, "mentor_profile.html", {'user': user, 'profile': profile,})
+    return render(request, "mentor_profile.html", {'mentor': user, 'mentor_profile': profile,})
 
 @login_required
 @mentor_only


### PR DESCRIPTION
Should fix #682 where viewing a mentor profile made it appear that you were logged in as them.

<!---
@huboard:{"custom_state":"archived"}
-->
