### PR TITLE
Handle non-json mailchimp error case

### DIFF
--- a/cmemails/mailchimp.py
+++ b/cmemails/mailchimp.py
@@ -44,7 +44,10 @@ def subscribe(user):
         }
     )
     if r.status_code != 200:
-        logger.warning("Mailchimp list signup returned an error: %s", r.json())
+        try:
+            logger.warning("Mailchimp list signup returned an error: %d %s", r.status_code, r.json())
+        except:
+            logger.warning("Mailchimp list signup returned a non-json error: %d", r.status_code)
     else:
         logger.info(
             "User %s email %s type %s subscribed to mailing list id %s"


### PR DESCRIPTION
Fix for `Jan 08 10:22:24 curiositymachine app/worker.1: severity=ERROR logger=rq.worker message="ValueError: No JSON object could be decoded`

Seems like mailchimp can return non-json responses in cases like a timed out request.

<!---
@huboard:{"custom_state":"archived"}
-->
