### PR TITLE
updated training section of boeing mentor registration page

### DIFF
--- a/profiles/templates/profiles/sources/boeing/mentor/join.html
+++ b/profiles/templates/profiles/sources/boeing/mentor/join.html
@@ -28,7 +28,7 @@
       <li>
         <h4>Self-Guided</h4>
         <p>A 90-minute self-guided online course with 3 tasks to complete: You can start this at any time.</p>
-        <p>To access self-guided training, create an account and go to the Training page on your dashboard.<p>
+        <p>To access self-guided training, create an account and go to the Training page on your dashboard.</p>
       </li>
     </ul>
 


### PR DESCRIPTION
Addresses issue #716. Currently looks like:

![image](https://cloud.githubusercontent.com/assets/6343358/12337950/bd8e5030-bad2-11e5-94b2-4de46b2cb30d.png)

@monicagragg Can you clarify the link that the button should go to? Not sure if it should be [this form](https://www.surveymonkey.com/r/YM25GQ8) or [this one](https://www.eventbrite.com/e/curiosity-machine-mentor-training-webinar-tickets-19712985069).


<!---
@huboard:{"custom_state":"archived"}
-->
