### PR TITLE
Remove pages app model

### DIFF
--- a/pages/admin.py
+++ b/pages/admin.py
@@ -1,4 +1,2 @@
 from django.contrib import admin
-from .models import Page
 
-admin.site.register(Page)

--- a/pages/migrations/0005_delete_page.py
+++ b/pages/migrations/0005_delete_page.py
@@ -1,0 +1,15 @@
+# encoding: utf8
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pages', '0004_auto_20140908_1433'),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name='Page',
+        ),
+    ]

--- a/pages/models.py
+++ b/pages/models.py
@@ -1,18 +1,1 @@
 from django.db import models
-from enum import Enum
-
-class StaticPage(Enum):
-    about = 1
-    privacy = 2
-    educator = 3
-    mentor = 4
-    parents = 5
-    faq = 6
-
-class Page(models.Model):
-    id = models.IntegerField(choices=[(page.value, page.name) for page in StaticPage], primary_key=True)
-    title = models.CharField(max_length=70, help_text="title of the page, in one line of plain text") # max_length based on Google maximum visible length for titles
-    text = models.TextField(help_text="contents of the page, in HTML")
-
-    def __str__(self):
-        return "Page: {}".format(self.title)


### PR DESCRIPTION
I assume this migration will delete the Pages model from the db, but might be worth running it and checking. Once this migration has been run in all environments we could remove the pages app from the repo entirely.

<!---
@huboard:{"custom_state":"archived"}
-->
