### PR TITLE
removing outdated information from cummins mentor sign up page

### DIFF
--- a/profiles/templates/profiles/sources/cummins/mentor/join.html
+++ b/profiles/templates/profiles/sources/cummins/mentor/join.html
@@ -33,24 +33,6 @@
       <li>Improve your communication and mentoring skills.</li>
       <li>Inspire the next generation by applying the skills you use every day.</li>
     </ul>
-    <h3>Time commitment</h3>
-    <ul>
-      <li>60 min Online Mentor Training Module</li>
-      <li>10 min each time you give feedback on a project</li>
-    </ul>
-    <h3>In-Person Mentoring Dates</h3>
-    <ul>
-      <li>Sept: 21, 23, 24, 25</li>
-      <li>Oct: 19, 21, 22, 23</li>
-      <li>Nov: 9, 11, 12, 13</li>
-    </ul> 
-    <h3>Online Mentoring Dates</h3>
-    <ul>
-      <li>Sept: 28, 30; Oct: 1, 2</li>
-      <li>Oct: 26, 28, 29, 30</li>
-      <li>Nov: 16, 18, 19, 20</li>
-      <li>Anytime after class time (10am EST)</li>
-    </ul>
   </div>
   <div class="col-md-6">
     <img src="{% static "images/mentor-and-daughter.jpg" %}" class="img-responsive">


### PR DESCRIPTION
This PR addresses issue #763, removing obsolete info from the Cummins sign up page. Looks like so:

![cummins](https://cloud.githubusercontent.com/assets/6343358/12988576/f9db7c98-d0c6-11e5-825e-28e98c92d57d.png)
