### PR TITLE
add photo language modal update for no photos

### DIFF
--- a/challenges/templates/challenges/examples/examples.html
+++ b/challenges/templates/challenges/examples/examples.html
@@ -55,25 +55,28 @@
               </button>
               <h3>Choose a Photo</h3>
             </div>
-            <div class="modal-body text-center">
-              <div class="row">
-                <div class="col-md-12">
-                  <p>Photos from {{ challenge.name }}</p>
+            <form method="POST" action="{% url "challenges:examples" challenge_id=challenge.id %}">
+              <div class="modal-body text-center">
+                <div class="row">
+                  {% csrf_token %}
+                  <div class="col-md-12">
+                    <p>Photos from {{ challenge.name }}</p>
+                  </div>
+                  {% for image in progress.get_student_images %}
+                  <div class="col-md-6">
+                    <input type="radio" name="example" id="example-{{image.id}}" value="{{image.id}}">
+                    <label for="example-{{image.id}}">
+                      <img src="{% resized image.url width=330 height=200 crop='fill' %}" alt="">
+                    </label>
+                  </div>
+                  {% endfor %}
                 </div>
-                {% for image in progress.get_student_images %}
-                <div class="col-md-6">
-                  <input type="radio" name="example" id="example-{{image.id}}" value="{{image.id}}">
-                  <label for="example-{{image.id}}">
-                    <img src="{% resized image.url width=330 height=200 crop='fill' %}" alt="">
-                  </label>
-                </div>
-                {% endfor %}
               </div>
-            </div>
-            <div class="modal-footer">
-              <a href="#" data-dismiss="modal" aria-label="Close">Cancel</a>
-              <input type="submit" class="btn btn-primary">
-            </div>
+              <div class="modal-footer">
+                <a href="#" data-dismiss="modal" aria-label="Close">Cancel</a>
+                <input type="submit" class="btn btn-primary">
+              </div>
+            </form>
           </div>
           {% else %}
           <div class="modal-content">
@@ -83,20 +86,17 @@
               </button>
               <h3>Choose a Photo</h3>
             </div>
-            <form method="POST" action="{% url "challenges:examples" challenge_id=challenge.id %}">
-              <div class="modal-body text-center">
-                <div class="row">
-                  {% csrf_token %}
-                  <div class="col-md-12">
-                    <p>You didn't post any photos to {{ challenge.name }}! Add a photo of your project, and then come back to share it in the Inspiration Gallery.</p>
-                  </div>
+            <div class="modal-body text-center">
+              <div class="row">
+                <div class="col-md-12">
+                  <p>You didn't post any photos to {{ challenge.name }}! Add a photo of your project, and then come back to share it in the Inspiration Gallery.</p>
                 </div>
               </div>
-              <div class="modal-footer">
-                <a href="#" data-dismiss="modal" aria-label="Close">Cancel</a>
-                <a href="{% url 'challenges:challenge_progress' challenge_id=challenge.id username=request.user.username %}" class="btn btn-primary">Return to Challenge</a>
-              </div>
-            </form>
+            </div>
+            <div class="modal-footer">
+              <a href="#" data-dismiss="modal" aria-label="Close">Cancel</a>
+              <a href="{% url 'challenges:challenge_progress' challenge_id=challenge.id username=request.user.username %}" class="btn btn-primary">Return to Challenge</a>
+            </div>
           </div>
           {% endif %}
         </div>


### PR DESCRIPTION
Updated per #725 QA, if you don't have any photos added to a project that you've completed (basically if you've gone through a DC with only text or video posts) the modal now looks like this:
![screen shot 2016-02-26 at 11 46 20 am](https://cloud.githubusercontent.com/assets/6343358/13360442/f483e780-dc7e-11e5-976e-16757c36ef47.png)
And the CTA brings you to your latest progress, which I believe is always going to be Reflect in this case anyway.

<!---
@huboard:{"custom_state":"archived"}
-->
