### PR TITLE
Examples quickfix

### DIFF
--- a/challenges/models.py
+++ b/challenges/models.py
@@ -196,7 +196,7 @@ class ExampleQuerySet(models.QuerySet):
 
     def from_progress(self, **kwargs):
         progress = kwargs.get('progress')
-        return self.filter(challenge=progress.challenge, progress=progress)
+        return self.filter(progress=progress)
 
     def status(self, **kwargs):
         qs = []


### PR DESCRIPTION
Fix for these papertrail errors:

```
Mar 21 17:19:14 curiositymachine app/web.2: severity=ERROR logger=django.request message="Internal Server Error: /challenges/8/examples/" 
Mar 21 17:19:14 curiositymachine app/web.2: Traceback (most recent call last): 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/core/handlers/base.py", line 113, in get_response 
Mar 21 17:19:14 curiositymachine app/web.2:     response = wrapped_callback(request, *callback_args, **callback_kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/python/lib/python3.3/site-packages/newrelic-2.50.0.39/newrelic/hooks/framework_django.py", line 499, in wrapper 
Mar 21 17:19:14 curiositymachine app/web.2:     return wrapped(*args, **kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/curiositymachine/decorators.py", line 78, in inner 
Mar 21 17:19:14 curiositymachine app/web.2:     return view(request, *args, **kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/views/generic/base.py", line 69, in view 
Mar 21 17:19:14 curiositymachine app/web.2:     return self.dispatch(request, *args, **kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/python/lib/python3.3/site-packages/newrelic-2.50.0.39/newrelic/hooks/framework_django.py", line 872, in wrapper 
Mar 21 17:19:14 curiositymachine app/web.2:     return wrapped(*args, **kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/views/generic/base.py", line 87, in dispatch 
Mar 21 17:19:14 curiositymachine app/web.2:     return handler(request, *args, **kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/utils/decorators.py", line 29, in _wrapper 
Mar 21 17:19:14 curiositymachine app/web.2:     return bound_func(*args, **kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/contrib/auth/decorators.py", line 22, in _wrapped_view 
Mar 21 17:19:14 curiositymachine app/web.2:     return view_func(request, *args, **kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/utils/decorators.py", line 25, in bound_func 
Mar 21 17:19:14 curiositymachine app/web.2:     return func.__get__(self, type(self))(*args2, **kwargs2) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/challenges/views.py", line 276, in post 
Mar 21 17:19:14 curiositymachine app/web.2:     if Example.objects.from_progress(progress=progress).status(approved=True, pending=True).exists(): 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/db/models/manager.py", line 92, in manager_method 
Mar 21 17:19:14 curiositymachine app/web.2:     return getattr(self.get_queryset(), name)(*args, **kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/challenges/models.py", line 199, in from_progress 
Mar 21 17:19:14 curiositymachine app/web.2:     return self.filter(challenge=progress.challenge, progress=progress) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/db/models/query.py", line 686, in filter 
Mar 21 17:19:14 curiositymachine app/web.2:     return self._filter_or_exclude(False, *args, **kwargs) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/db/models/query.py", line 704, in _filter_or_exclude 
Mar 21 17:19:14 curiositymachine app/web.2:     clone.query.add_q(Q(*args, **kwargs)) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/db/models/sql/query.py", line 1284, in add_q 
Mar 21 17:19:14 curiositymachine app/web.2:     clause, require_inner = self._add_q(where_part, self.used_aliases) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/db/models/sql/query.py", line 1311, in _add_q 
Mar 21 17:19:14 curiositymachine app/web.2:     current_negated=current_negated, connector=connector) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/db/models/sql/query.py", line 1138, in build_filter 
Mar 21 17:19:14 curiositymachine app/web.2:     lookups, parts, reffed_aggregate = self.solve_lookup_type(arg) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/db/models/sql/query.py", line 1076, in solve_lookup_type 
Mar 21 17:19:14 curiositymachine app/web.2:     _, field, _, lookup_parts = self.names_to_path(lookup_splitted, self.get_meta()) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/db/models/sql/query.py", line 1380, in names_to_path 
Mar 21 17:19:14 curiositymachine app/web.2:     self.raise_field_error(opts, name) 
Mar 21 17:19:14 curiositymachine app/web.2:   File "/app/.heroku/src/django/django/db/models/sql/query.py", line 1386, in raise_field_error 
Mar 21 17:19:14 curiositymachine app/web.2:     "Choices are: %s" % (name, ", ".join(available))) 
Mar 21 17:19:14 curiositymachine app/web.2: django.core.exceptions.FieldError: Cannot resolve keyword 'challenge' into field. Choices are: approved, created_at, id, image, image_id, progress, progress_id, updated_at 
```

<!---
@huboard:{"custom_state":"archived"}
-->
