### PR TITLE
Add DJANGO_SETTINGS_MODULE to pytest ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 python_files=test*.py
 addopts = -p no:doctest
+DJANGO_SETTINGS_MODULE = curiositymachine.test_settings


### PR DESCRIPTION
This starts to do away with the need for `make test` to run tests. This takes care of the django settings, and `add2virtualenv .` takes care of the `PYTHONPATH=.` part of the `Makefile` test rule. With those two things, you can run tests with `$ py.test` which is much nicer than `make`, and lets you do fun things like assign hot keys to run tests from within vim (thanks joe!). :+1: 

<!---
@huboard:{"custom_state":"archived"}
-->
