### PR TITLE
change link to ToU

### DIFF
--- a/profiles/templates/profiles/educator/join.html
+++ b/profiles/templates/profiles/educator/join.html
@@ -40,8 +40,8 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-12">
-      By clicking Save, you confirm that you accept the <a target="_blank" href="/privacy">Privacy Policy</a>.
+    <div class="col-md-8">
+      By joining Curiosity Machine, you confirm that you accept our <a target="_blank" href="{% url 'terms-of-use' %}">Terms of Use</a>.
       <button type="submit" class="btn btn-primary btn-lg pull-right">Save</button>
     </div>
   </div>

--- a/profiles/templates/profiles/mentor/join.html
+++ b/profiles/templates/profiles/mentor/join.html
@@ -16,7 +16,7 @@
   <div class="row">
     <div class="col-md-8">
       <p>
-        By clicking Save, you confirm that you accept the <a target="_blank" href="/privacy">Privacy Policy</a>.
+        By joining Curiosity Machine, you confirm that you accept our <a target="_blank" href="{% url 'terms-of-use' %}">Terms of Use</a>.
       </p>
       <button type="submit" class="btn btn-primary btn-lg pull-right">Save</button>
     </div>

--- a/profiles/templates/profiles/parent/join.html
+++ b/profiles/templates/profiles/parent/join.html
@@ -40,8 +40,8 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-md-12">
-      By clicking Save, you confirm that you accept the <a target="_blank" href="/privacy">Privacy Policy</a>.
+    <div class="col-md-8">
+      By joining Curiosity Machine, you confirm that you accept our <a target="_blank" href="{% url 'terms-of-use' %}">Terms of Use</a>.
       <button type="submit" class="btn btn-primary btn-lg pull-right">Save</button>
     </div>
   </div>

--- a/profiles/templates/profiles/student/join.html
+++ b/profiles/templates/profiles/student/join.html
@@ -19,7 +19,7 @@
           {{form.birthday}}
           <div class="errors">{{ form.birthday.errors }}</div>
         </div>
-      
+
         <div>
           {{form.username.label_tag}}
           {{form.username}}
@@ -75,7 +75,7 @@
       {{ form.non_field_errors }}
     </div>
   </div>
-  By clicking Save, you confirm that you accept the <a target="_blank" href="/privacy">Privacy Policy</a>.
+  <p>By joining Curiosity Machine, you confirm that you accept our <a target="_blank" href="{% url 'terms-of-use' %}">Terms of Use</a>.</p>
   <button type="submit" class="btn btn-primary btn-lg pull-right">Save</button>
 </form>
 


### PR DESCRIPTION
This PR changes the link & text in the bottom of all of the /join & /join_as pages to the Terms of Use pages instead of the Privacy Policy, for ticket #870.

<!---
@huboard:{"custom_state":"archived"}
-->
