### PR TITLE
[#884] "Login" to "Log In"

### DIFF
--- a/curiositymachine/templates/curiositymachine/_header.html
+++ b/curiositymachine/templates/curiositymachine/_header.html
@@ -34,7 +34,7 @@
         <div class="modal-footer">
           <a href="{% url "password_reset_recover" %}">Forgot your password?</a>
           <a class="btn btn-link" data-dismiss="modal" aria-hidden="true">Cancel</a>
-          <input type="submit" value="Log in" class="btn btn-primary" />
+          <input type="submit" value="Log In" class="btn btn-primary" />
           <input type="hidden" name="next" value="{{ next|default:'/' }}" />
         </div>
       </form>

--- a/curiositymachine/templates/registration/_login_modal.html
+++ b/curiositymachine/templates/registration/_login_modal.html
@@ -15,7 +15,7 @@
     <div class="modal-footer">
       <a href="{% url "password_reset_recover" %}">Forgot your password?</a>
       <a class="btn btn-link btn-lg" data-dismiss="modal" aria-hidden="true">Cancel</a>
-      <input type="submit" value="login" class="btn btn-primary btn-lg" />
+      <input type="submit" value="Log In" class="btn btn-primary btn-lg" />
       {% if next %}
           <input type="hidden" name="next" value="{{ next }}" />
       {% else %}

--- a/curiositymachine/templates/registration/login.html
+++ b/curiositymachine/templates/registration/login.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="login-top-panel">
-  <h1>Login</h1>
+  <h1>Log In</h1>
 </div>
 
 <div class="container">
@@ -23,7 +23,7 @@
     <form method="post" id="login-page-form" action="{% url 'login' %}">
         {% include "registration/_login_form.html" %}
 
-        <p><input type="submit" class="btn btn-primary login-btn" value="Login" class="btn btn-primary btn-lg" /> <small><a href="{% url "password_reset_recover" %}">Forgot your password?</a></small></p>
+        <p><input type="submit" class="btn btn-primary login-btn" value="Log In" class="btn btn-primary btn-lg" /> <small><a href="{% url "password_reset_recover" %}">Forgot your password?</a></small></p>
 
         {% if next %}
             <input type="hidden" name="next" value="{{ next }}" />


### PR DESCRIPTION
Changes "Login" and "Log in" to "Log In." 

A note: though I updated `curiositymachine/templates/registration/_login_modal.html`, I don't think there are actually any pages that use that modal now -- since we've done the landing pages, you can't see any pages with the "old" templates while logged out. (That I can think of.) All the new pages have the Log In modal embedded in the header.

<!---
@huboard:{"custom_state":"archived"}
-->
