### PR TITLE
[#946] Make membership member admin show raw id fields

### DIFF
--- a/memberships/admin.py
+++ b/memberships/admin.py
@@ -56,6 +56,7 @@ class MembershipAdmin(admin.ModelAdmin):
 class MemberAdmin(admin.ModelAdmin):
     list_display = ('id', 'membership', 'user')
     search_fields = ('membership__name', 'user__username')
+    raw_id_fields = ('membership', 'user',)
 
 admin.site.register(Membership, MembershipAdmin)
 admin.site.register(Member, MemberAdmin)


### PR DESCRIPTION
This should make Membership > Members model creation work better for production.

<img width="850" alt="screen shot 2016-08-23 at 2 23 36 pm" src="https://cloud.githubusercontent.com/assets/55319/17904420/398a3ea6-693d-11e6-9fe1-51e505b58fea.png">
<img width="1173" alt="screen shot 2016-08-23 at 2 23 40 pm" src="https://cloud.githubusercontent.com/assets/55319/17904421/3ad0a318-693d-11e6-821f-516057f22f45.png">

<!---
@huboard:{"custom_state":"archived"}
-->
