### PR TITLE
[#975] Order progresses to be claimed by started in descending order

### DIFF
--- a/challenges/models.py
+++ b/challenges/models.py
@@ -109,7 +109,7 @@ class Progress(models.Model):
         where cmcomments_comment.challenge_progress_id IS NOT NULL
         and challenges_progress.mentor_id IS NULL
         group by DATE(challenges_progress.started)
-        order by started
+        order by started DESC
         """
         cursor = connection.cursor()
         cursor.execute(query)

--- a/profiles/views/mentor.py
+++ b/profiles/views/mentor.py
@@ -74,7 +74,7 @@ def home(request):
                 ).select_related(
                     "challenge__image"
                 ).order_by(
-                    "started"
+                    "-started"
                 ).first()
         } for obj in source_and_counts
     }
@@ -150,7 +150,7 @@ def unclaimed_progresses(request, **kwargs):
         ).exclude(
             comments=None
         ).order_by(
-            'started'
+            '-started'
         ).select_related(
            'challenge', 'student', 'student__profile', 'student__profile__image', 'challenge__image'
         )
@@ -162,7 +162,7 @@ def unclaimed_progresses(request, **kwargs):
         ).exclude(
                 comments=None
         ).order_by(
-                'started'
+                '-started'
         ).select_related(
                 'challenge', 'student', 'student__profile', 'student__profile__image', 'challenge__image'
         )


### PR DESCRIPTION
For #975, orders claimable progresses in descending date order throughout mentor dashboard.

<!---
@huboard:{"custom_state":"archived"}
-->
