### PR TITLE
[#991] remove start building button from examples page, fix tests

### DIFF
--- a/challenges/templates/challenges/examples/examples.html
+++ b/challenges/templates/challenges/examples/examples.html
@@ -41,17 +41,6 @@
     </div>
     {% endif %}
 
-    <!-- student who has not started the design challenge -->
-    {% if request.user.profile.is_student and not progress %}
-    <div id="student-not-started" class="examples-page-alerts text-center p-a-md m-y-md">
-      <h3>Want to {{ challenge.name }}?</h3>
-      <form name="Start Building" action='{% url "challenges:start_building" challenge_id=challenge.id %}' method='POST'>
-      {% csrf_token %}
-        <input type="submit" value="Start Building" class="btn btn-primary"/>
-      </form>
-    </div>
-    {% endif %}
-
     <!-- student who has started the challenge AND posted in Reflect progress -->
     {% if progress.completed and not user_example %}
     <div id="student-completed" class="examples-page-alerts text-center p-a-md m-y-md">

--- a/challenges/tests/integration/test_challenges_app.py
+++ b/challenges/tests/integration/test_challenges_app.py
@@ -341,7 +341,6 @@ def test_examples_view_for_student_without_progress(client):
     assert not response.context['user_example']
 
     d = pq(response.content)
-    assert d('#student-not-started')
     assert not d('#student-in-progress')
     assert not d('#student-completed')
     assert not d('#student-example-pending')
@@ -360,7 +359,6 @@ def test_examples_view_for_student_with_progress_without_example(client):
     assert not response.context['user_example']
 
     d = pq(response.content)
-    assert not d('#student-not-started')
     assert d('#student-in-progress')
     assert not d('#student-completed')
     assert not d('#student-example-pending')
@@ -379,7 +377,6 @@ def test_examples_view_for_student_with_completed_progress_without_example(clien
     assert not response.context['user_example']
 
     d = pq(response.content)
-    assert not d('#student-not-started')
     assert not d('#student-in-progress')
     assert d('#student-completed')
     assert not d('#student-example-pending')
@@ -400,7 +397,6 @@ def test_examples_view_for_student_with_completed_progress_with_example_pending(
     assert example in response.context['examples']
 
     d = pq(response.content)
-    assert not d('#student-not-started')
     assert not d('#student-in-progress')
     assert not d('#student-completed')
     assert d('#student-example-pending')
@@ -421,7 +417,6 @@ def test_examples_view_for_student_with_completed_progress_with_example_approved
     assert example in response.context['examples']
 
     d = pq(response.content)
-    assert not d('#student-not-started')
     assert not d('#student-in-progress')
     assert not d('#student-completed')
     assert not d('#student-example-pending')
@@ -442,7 +437,6 @@ def test_examples_view_for_student_with_completed_progress_with_example_rejected
     assert example not in response.context['examples']
 
     d = pq(response.content)
-    assert not d('#student-not-started')
     assert not d('#student-in-progress')
     assert d('#student-completed')
     assert not d('#student-example-pending')
@@ -456,7 +450,6 @@ def test_examples_view_for_non_student(client):
     response = client.get('/challenges/%d/examples' % (challenge.id), follow=True)
 
     d = pq(response.content)
-    assert not d('#student-not-started')
     assert not d('#student-in-progress')
     assert not d('#student-completed')
     assert not d('#student-example-pending')

--- a/cmemails/tests.py
+++ b/cmemails/tests.py
@@ -214,11 +214,10 @@ def test_send_welcome_email_skips_excluded_user_types():
     mentor = profiles.factories.MentorFactory.build()
     none = profiles.factories.UserFactory.build()
 
-    with mock.patch('cmemails.signals.handlers.send') as send, mock.patch('cmemails.signals.handlers.deliver_email') as deliver_email:
+    with mock.patch('cmemails.signals.handlers.send') as send:
         signals.handlers.send_welcome_email(mentor)
         signals.handlers.send_welcome_email(none)
         assert not send.called
-        assert not deliver_email.called
 
 def test_send_welcome_email_differentiates_user_categories():
     student = profiles.factories.StudentFactory.build()


### PR DESCRIPTION
For #991 
Removes the start building button from examples, which shows regardless of membership access right now. 😱 

<!---
@huboard:{"custom_state":"archived"}
-->
