### PR TITLE
restore custom filter header

### DIFF
--- a/challenges/templates/challenges/filters/test.html
+++ b/challenges/templates/challenges/filters/test.html
@@ -1,0 +1,1 @@
+<h2>test header_template</h2>

--- a/challenges/templates/challenges/new.html
+++ b/challenges/templates/challenges/new.html
@@ -30,8 +30,8 @@
 
     <div class="col-md-7 col-lg-8 col-xl-9">
       <h4 class="all-challenges-header text-center" id="challenges">{{title|safe}}</h4>
-      {% if active_filter.header_template %}
-        {% include active_filter.header_template %}
+      {% if header_template %}
+        {% include header_template %}
       {% endif %}
       <div class="all-challenges-cards">
 

--- a/challenges/tests/integration/test_challenges_view.py
+++ b/challenges/tests/integration/test_challenges_view.py
@@ -144,3 +144,10 @@ def test_challenges_does_not_decorate_has_resources_for_student_or_anonymous(cli
     response = client.get('/challenges/')
     for challenge in response.context['challenges']:
         assert not hasattr(challenge, 'has_resources')
+
+@pytest.mark.django_db
+def test_shows_filter_header_template(client):
+    f = FilterFactory(header_template='challenges/filters/test.html')
+    response = client.get('/challenges/', {"filter_id": f.id})
+
+    assert b'test header_template' in response.content


### PR DESCRIPTION
I discovered this was broken while working on fixtures, so I fixed it.

Basically when a filter defines a `header_template` to use to add stuff to the filtered view (Boeing's filter does this), that wasn't working any more. It should work again, and I added a test to hopefully catch it if it breaks again.

<!---
@huboard:{"custom_state":"archived","order":1047,"milestone_order":1047}
-->
