### PR TITLE
[#956] updates preview challenge language

### DIFF
--- a/challenges/templates/challenges/edp/preview/inspiration_user.html
+++ b/challenges/templates/challenges/edp/preview/inspiration_user.html
@@ -3,7 +3,7 @@
 {% block jumbotron_message %}
 
   {% if challenge.accessible %}
-    <a href="{% url 'challenges:preview_plan' challenge_id=challenge.id %}" class="btn btn-secondary btn-lg">Preview Challenge</a>
+    <a href="{% url 'challenges:preview_plan' challenge_id=challenge.id %}" class="btn btn-secondary btn-lg">View Challenge</a>
   {% else %}
     <div class="membership-only">
       <p>Explore the full design challenge by joining a membership!</p>

--- a/challenges/templates/challenges/new.html
+++ b/challenges/templates/challenges/new.html
@@ -97,12 +97,6 @@
                           <span class="accessible-dc">Build it!</span>
                         </small>
                       </li>
-                      {% else %}
-                      <li>
-                        <small>
-                          <span class="accessible-dc">Preview!</span>
-                        </small>
-                      </li>
                       {% endif %}
                       {% endif %}
                       {% if not request.user.profile.is_student and challenge.has_resources %}

--- a/challenges/templates/challenges/preview/_alerts.html
+++ b/challenges/templates/challenges/preview/_alerts.html
@@ -13,6 +13,6 @@
   </div>
 {% else %}
   <div class="alert alert-info text-center preview-page-alerts">
-    <strong>You're previewing this challenge.</strong> Only students can post their design challenge progress.
+    <strong>Only students can post their design challenge progress.</strong> For resources and help, check out the Guide tab.
   </div>
 {% endif %}


### PR DESCRIPTION
This PR updates the preview challenge language according to the list in #956:
- remove "Preview" flag from all DCs
- change CTA on "Preview Challenge" to say "View Challenge" 
- change language in Preview alert on EDP to say "**Only students can post their design challenge progress.** For resources and help, check out the Guide tab."

_Note: the banner update list item from #956 will happen in a separate ticket_


<!---
@huboard:{"custom_state":"archived"}
-->
