### PR TITLE
[#1103] make images in units admin raw id fields

### DIFF
--- a/units/admin.py
+++ b/units/admin.py
@@ -22,6 +22,7 @@ class UnitAdmin(admin.ModelAdmin):
     inlines = [
         UnitItemInline, ResourceInline
     ]
+    raw_id_fields = ('image', 'standards_alignment_image')
 
 class ResourceAdmin(admin.ModelAdmin):
     model = Resource


### PR DESCRIPTION
For #1103, changes the units admin to show images like this:

<img width="783" alt="screen shot 2016-11-09 at 12 33 52 pm" src="https://cloud.githubusercontent.com/assets/55319/20148054/d1712a90-a678-11e6-9478-779f6ca4c018.png">

which avoids the immensely long dropdowns.

<!---
@huboard:{"custom_state":"archived"}
-->
