### PR TITLE
select_related in user admin to reduce queries for profiles

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -24,6 +24,7 @@ class UserAdminWithProfile(UserAdmin):
         'profile__role',
         StudentFilter
     )
+    list_select_related = ('profile',)
     search_fields = ('username', 'email', 'first_name', 'last_name', 'profile__source')
 
     def source(self, obj):

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,6 +2,6 @@
 -r ./requirements.txt
 
 # and some development-only extras
-django-debug-toolbar==1.2.2
+django-debug-toolbar==1.5
 pyquery==1.2.11
 pytest-cov==2.2.1


### PR DESCRIPTION
For #1160, shows how [this](https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_select_related) can be used to reduce admin queries.

<!---
@huboard:{"custom_state":"archived"}
-->
