### PR TITLE
[#1215] track guide button clicks and tab selections

### DIFF
--- a/challenges/templates/_guide.html
+++ b/challenges/templates/_guide.html
@@ -12,22 +12,58 @@
     </div>
     <ul class="nav nav-tabs upwards">
       <li class="active">
-        <a href="#guide-how-to" data-toggle="tab">How To Make It</a>
+        <a
+          href="#guide-how-to"
+          data-toggle="tab"
+          ga-on="click"
+          ga-event-category="Tab"
+          ga-event-action="select"
+          ga-event-label="How to make it"
+        >
+          How To Make It
+        </a>
       </li>
 
       <li>
-        <a href="#guide-more-info" data-toggle="tab">Learn More</a>
+        <a
+          href="#guide-more-info"
+          data-toggle="tab"
+          ga-on="click"
+          ga-event-category="Tab"
+          ga-event-action="select"
+          ga-event-label="Learn more"
+        >
+          Learn More
+        </a>
       </li>
 
       {% if request.user.is_authenticated and request.user.profile.is_mentor and challenge.mentor_guide %}
       <li>
-        <a href="#mentor-guide" data-toggle="tab">Mentor Guide</a>
+        <a
+          href="#mentor-guide"
+          data-toggle="tab"
+          ga-on="click"
+          ga-event-category="Tab"
+          ga-event-action="select"
+          ga-event-label="Mentor guide"
+        >
+          Mentor Guide
+        </a>
       </li>
       {% endif %}
 
       {% if request.user.is_authenticated and not request.user.profile.is_student and resources %}
       <li>
-        <a href="#resources" data-toggle="tab">Resources</a>
+        <a
+          href="#resources"
+          data-toggle="tab"
+          ga-on="click"
+          ga-event-category="Tab"
+          ga-event-action="select"
+          ga-event-label="Resources"
+        >
+          Resources
+        </a>
       </li>
       {% endif %}
     </ul>

--- a/challenges/templates/challenges/preview/_nav.html
+++ b/challenges/templates/challenges/preview/_nav.html
@@ -2,7 +2,15 @@
   <nav class="challenge-nav primary">
     <ul>
       <li class="guide">
-        <a data-toggle="modal"  data-target="#guide-modal" href="#">
+        <a
+          data-toggle="modal"
+          data-target="#guide-modal"
+          href="#"
+          ga-on="click"
+          ga-event-category="Button"
+          ga-event-action="click"
+          ga-event-label="Guide button"
+        >
           <span class="btn" >Guide</span>
         </a>
       </li>

--- a/challenges/templates/challenges/progress/_nav.html
+++ b/challenges/templates/challenges/progress/_nav.html
@@ -2,7 +2,15 @@
   <nav class="challenge-nav primary">
     <ul>
       <li class="guide">
-        <a data-toggle="modal"  data-target="#guide-modal" href="#">
+        <a
+          data-toggle="modal"
+          data-target="#guide-modal"
+          href="#"
+          ga-on="click"
+          ga-event-category="Button"
+          ga-event-action="click"
+          ga-event-label="Guide button"
+        >
           <span class="btn" >Guide</span>
         </a>
       </li>

--- a/curiositymachine/templates/base.html
+++ b/curiositymachine/templates/base.html
@@ -69,6 +69,7 @@
 
     ga('create', '{{ga_code}}', 'auto');
     ga('require', 'outboundLinkTracker');
+    ga('require', 'eventTracker');
     ga('require', 'cleanUrlTracker', {
       stripQuery: true,
       queryDimensionIndex: 2,

--- a/curiositymachine/templates/curiositymachine/layout/base.html
+++ b/curiositymachine/templates/curiositymachine/layout/base.html
@@ -61,6 +61,7 @@
 
       ga('create', '{{ga_code}}', 'auto');
       ga('require', 'outboundLinkTracker');
+      ga('require', 'eventTracker');
       ga('require', 'cleanUrlTracker', {
         stripQuery: true,
         queryDimensionIndex: 2,


### PR DESCRIPTION
For #1215 (and incidentally #997) this introduces the autotrack eventTracker plugin, and uses it to try to track guide button clicks and tab selections. I'm not sure the event are organized in the best way but this at least starts sending some data in to GA somehow about these things and we'll go from there.

<!---
@huboard:{"custom_state":"archived"}
-->
