### PR TITLE
[#1193] Prevent 500s due to no email during password recovery

### DIFF
--- a/curiositymachine/templates/password_reset/reset_sent.html
+++ b/curiositymachine/templates/password_reset/reset_sent.html
@@ -8,9 +8,12 @@
 <div class="jumbotron-fluid jumbotron-green text-xs-center">
   <h1>Reset Password</h1>
 </div>
-<div class="container mb-3">
-  <p class="text-xs-center">
+<div class="container mb-3 text-xs-center">
+  <p>
     An email was sent to <strong>{{ email }}</strong> {{ timestamp|timesince }} ago. Use the link in it to set a new password.
+  </p>
+  <p>
+    If you do not receive a password reset email, please <a href="mailto:curiosity@iridescentlearning.org">contact us</a>.
   </p>
 </div>
 {% endblock %}

--- a/profiles/views/__init__.py
+++ b/profiles/views/__init__.py
@@ -2,6 +2,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import Http404
 import password_reset.views
 import password_reset.forms
+from smtplib import SMTPRecipientsRefused
 import logging
 
 from . import student
@@ -41,7 +42,7 @@ class Recover(password_reset.views.Recover):
     def send_notification(self):
         try:
             super().send_notification()
-        except smtplib.SMTPRecipientsRefused as ex:
+        except SMTPRecipientsRefused as ex:
             # swallow (but log) SMTPRecipientsRefused errors
             logger.warning("Password reset recipients refused", exc_info=ex)
         except:


### PR DESCRIPTION
For #1193, this should let users with no email address in the db still get to the "email sent" page.

<!---
@huboard:{"custom_state":"archived"}
-->
