### PR TITLE
Get in touch email on memberships page

### DIFF
--- a/curiositymachine/templates/curiositymachine/pages/about-membership.html
+++ b/curiositymachine/templates/curiositymachine/pages/about-membership.html
@@ -23,8 +23,7 @@
           own (check out the "free" and "Boeing" filters on the design challenge page once you create your free account!).
         </p>
         <p>
-          If you have questions about memberships, we'd love to help! Please get in touch with our Director of Community Partnerships,
-          <a href="mailto:judith@iridescentlearning.org">Judith Ahumada</a>.
+          If you have questions about memberships, we'd love to help! Get in touch with us at <a href="mailto:curiosity@iridescentlearning.org">curiosity@iridescentlearning.org</a>.
         </p>
         <p>Curiosity Machine memberships can include: </p>
         <ul>


### PR DESCRIPTION
This PR changes our "get in touch" email on the memberships page to be curiosity@ instead of Judy's work email, per Maggie's request.

<!---
@huboard:{"custom_state":"archived"}
-->
