### PR TITLE
Autogenerate url config for static templates

### DIFF
--- a/curiositymachine/settings.py
+++ b/curiositymachine/settings.py
@@ -69,7 +69,6 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.sites',
     'django.contrib.flatpages',
-    'staticflatpages',
     'profiles',
     'challenges',
     'cmcomments',
@@ -107,7 +106,6 @@ MIDDLEWARE_CLASSES = (
     'curiositymachine.middleware.LastActiveMiddleware',
     'curiositymachine.middleware.FirstLoginMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
-    'staticflatpages.middleware.StaticFlatpageFallbackMiddleware',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/curiositymachine/templates/curiositymachine/pages/about-membership.html
+++ b/curiositymachine/templates/curiositymachine/pages/about-membership.html
@@ -6,7 +6,9 @@
 {% block body-id %}membership-about-page{% endblock %}
 
 {% block content %}
-  {{ block.super }}
+  {% with active_nav='membership' %}
+    {{ block.super }}
+  {% endwith %}
 
   <div class="container">
     <div class="row">

--- a/curiositymachine/templates/curiositymachine/pages/about-partnership.html
+++ b/curiositymachine/templates/curiositymachine/pages/about-partnership.html
@@ -6,7 +6,9 @@
 {% block body-id %}partnership-about-page{% endblock %}
 
 {% block content %}
-  {{ block.super }}
+  {% with active_nav='partnership' %}
+    {{ block.super }}
+  {% endwith %}
 
   <div class="container">
     <div class="row">

--- a/curiositymachine/templates/curiositymachine/pages/about.html
+++ b/curiositymachine/templates/curiositymachine/pages/about.html
@@ -6,7 +6,9 @@
 {% block body-id %}about-page{% endblock %}
 
 {% block content %}
-  {{ block.super }}
+  {% with active_nav='about' %}
+    {{ block.super }}
+  {% endwith %}
 
   <div class="container">
     <div class="row">

--- a/curiositymachine/templates/curiositymachine/pages/community-guidelines.html
+++ b/curiositymachine/templates/curiositymachine/pages/community-guidelines.html
@@ -5,7 +5,9 @@
 {% block body-id %}community-guidelines-about-page{% endblock %}
 
 {% block content %}
-  {{ block.super }}
+  {% with active_nav='community-guidelines' %}
+    {{ block.super }}
+  {% endwith %}
 
   <div class="container">
     <div class="row">

--- a/curiositymachine/templates/curiositymachine/pages/educator.html
+++ b/curiositymachine/templates/curiositymachine/pages/educator.html
@@ -5,7 +5,9 @@
 {% block title %}Educators{% endblock %}
 
 {% block content %}
-  {{ block.super }}
+  {% with active_nav='educator' %}
+    {{ block.super }}
+  {% endwith %}
 
   <div class="container">
     <div class="row">

--- a/curiositymachine/templates/curiositymachine/pages/mentor.html
+++ b/curiositymachine/templates/curiositymachine/pages/mentor.html
@@ -6,7 +6,9 @@
 {% block body-id %}mentor-about-page{% endblock %}
 
 {% block content %}
-  {{ block.super }}
+  {% with active_nav='mentor' %}
+    {{ block.super }}
+  {% endwith %}
 
   <div class="container">
     <div class="row">

--- a/curiositymachine/templates/curiositymachine/pages/parents.html
+++ b/curiositymachine/templates/curiositymachine/pages/parents.html
@@ -6,7 +6,9 @@
 {% block body-id %}parent-about-page{% endblock %}
 
 {% block content %}
-  {{ block.super }}
+  {% with active_nav='parents' %}
+    {{ block.super }}
+  {% endwith %}
 
   <div class="container pb-3">
     <div class="row">


### PR DESCRIPTION
`staticflatpages` had the downside of not providing url mappings for the static templates which, while not the end of the world, made me nervous about broken links as the site evolves. This solution reads a particular directory and generates url config for each template in there where for e.g. `template.html` the url would be `/template/` and the name for reversing `{% url "template" %}`.

I updated the about page templates to set `active_nav` correctly.

Since we don't currently have a `staticflatpages` directory at all, I'm removing it from the project too.