### PR TITLE
removed link from mentor community page

### DIFF
--- a/profiles/templates/profiles/mentor-community.html
+++ b/profiles/templates/profiles/mentor-community.html
@@ -54,9 +54,5 @@
     </div>
   </div>
 
-  <div class="sign-up-panel py-3">
-    <h2>Interesting in mentoring? Complete this interest form!</h2>
-    <a href="http://goo.gl/forms/CYzaS5AOufWZi8kh1" target="_blank" class="btn btn-orange-secondary text-uppercase">View Form</a>
-  </div>
 
 {% endblock %}


### PR DESCRIPTION
There is another broken mentor interest form link [here](https://www.curiositymachine.org/mentors/)

Removed the banner and link 

<!---
@huboard:{"custom_state":"archived"}
-->
