### PR TITLE
Require educators to include an org when signing up

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -128,6 +128,7 @@ class Educator(Profile):
 class EducatorAdmin(admin.ModelAdmin):
     fields = [
         'user',
+        'organization',
         'city',
         'image',
         'approved',
@@ -135,7 +136,7 @@ class EducatorAdmin(admin.ModelAdmin):
         'last_inactive_email_sent_on',
     ]
     raw_id_fields = ['image']
-    list_display = ['user', 'email', 'id']
+    list_display = ['user', 'email', 'id', 'organization']
     search_fields = [
         'user__username',
         'user__email',

--- a/profiles/forms/educator.py
+++ b/profiles/forms/educator.py
@@ -5,12 +5,13 @@ from profiles.models import UserRole
 class EducatorUserAndProfileForm(UserAndProfileForm):
     profile_fields = [
         'city',
-        'source'
+        'source',
+        'organization'
     ]
     profile_fields_force = {
         'role': UserRole.educator.value
     }
-    make_required = ['email', 'city']
+    make_required = ['email', 'city', 'organization']
 
     form_fields = ['image_url', 'welcome']
 
@@ -22,3 +23,6 @@ class EducatorUserAndProfileForm(UserAndProfileForm):
             'first_name',
             'last_name'
         ]
+
+class EducatorUserAndProfileChangeForm(EducatorUserAndProfileForm):
+    make_required = ['email', 'city']

--- a/profiles/migrations/0033_profile_organization.py
+++ b/profiles/migrations/0033_profile_organization.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0032_impactsurvey'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='organization',
+            field=models.CharField(help_text='This is an educator field.', max_length=50, blank=True, null=True),
+        ),
+    ]

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -28,6 +28,7 @@ class Profile(models.Model):
     employer = models.TextField(blank=True, help_text="This is a mentor only field.")
     expertise = models.TextField(blank=True, help_text="This is a mentor only field.")
     about_me = models.TextField(blank=True, help_text="This is a mentor only field.")
+    organization = models.CharField(max_length=50, null=True, blank=True, help_text="This is an educator field.")
     about_me_image = models.ForeignKey(Image, null=True, blank=True, on_delete=models.SET_NULL, related_name="about_me_image")
     about_me_video = models.ForeignKey(Video, null=True, blank=True, on_delete=models.SET_NULL, related_name="about_me_video")
 

--- a/profiles/templates/profiles/educator/join.html
+++ b/profiles/templates/profiles/educator/join.html
@@ -30,6 +30,7 @@
       {% include "profiles/formfield.html" with field=form.first_name %}
       {% include "profiles/formfield.html" with field=form.last_name %}
       {% include "profiles/formfield.html" with field=form.city %}
+      {% include "profiles/formfield.html" with field=form.organization %}
       {% include "profiles/formfield.html" with field=form.image_url %}
     </div>
     <div class="col-md-4">

--- a/profiles/templates/profiles/educator/profile_edit.html
+++ b/profiles/templates/profiles/educator/profile_edit.html
@@ -86,6 +86,16 @@
                   {% endfor %}
                 </div>
               </div>
+
+              <div class="form-group {% if form.organization.errors %} has-danger {% endif %}">
+                {{ form.organization.label_tag }}
+                {{ form.organization|add_class:"form-control" }}
+                <div class="errors">
+                  {% for error in form.organization.errors.as_data %}
+                  <div class="form-control-feedback">{{ error.message }}</div>
+                  {% endfor %}
+                </div>
+              </div>
             </div>
 
             <hr>

--- a/profiles/tests/test_educator.py
+++ b/profiles/tests/test_educator.py
@@ -15,7 +15,7 @@ User = get_user_model()
 def test_form_required_fields_on_creation():
     f = forms.educator.EducatorUserAndProfileForm()
 
-    required = ['username', 'email', 'password', 'confirm_password', 'city']
+    required = ['username', 'email', 'password', 'confirm_password', 'city', 'organization']
     for name, field in f.fields.items():
         if name in required:
             assert field.required, "%s should be required and isn't" % name
@@ -29,7 +29,7 @@ def test_form_required_fields_on_edit():
     user = User()
     profile = models.Profile()
     profile.user = user
-    f = forms.educator.EducatorUserAndProfileForm(instance=user)
+    f = forms.educator.EducatorUserAndProfileChangeForm(instance=user)
 
     required = ['email', 'city']
     for name, field in f.fields.items():
@@ -93,7 +93,8 @@ def test_creates_user_with_profile():
         'confirm_password': '123123',
         'username': 'example',
         'email': 'email@example.com',
-        'city': 'mycity'
+        'city': 'mycity',
+        'organization': 'my org',
     })
     assert f.is_valid()
     user = f.save()
@@ -109,13 +110,15 @@ def test_modifies_exisiting_user_and_profile():
         'username': 'example',
         'email': 'email@example.com',
         'city': 'mycity',
+        'organization': 'my org',
     })
     user = f.save()
     f = forms.educator.EducatorUserAndProfileForm(
         instance=user,
         data={
             'email': 'new@example.com',
-            'city': 'newcity'
+            'city': 'newcity',
+            'organization': 'new org',
         }
     )
     user = f.save()
@@ -131,7 +134,8 @@ def test_sets_educator_role():
         'confirm_password': '123123',
         'username': 'example',
         'email': 'email@example.com',
-        'city': 'mycity'
+        'city': 'mycity',
+        'organization': 'my org',
     })
     user = f.save()
     assert user.profile.is_educator
@@ -166,7 +170,8 @@ def test_educator_profile_change_form_creates_image_from_image_url():
         'confirm_password': '123123',
         'username': 'example',
         'email': 'email@example.com',
-        'city': 'mycity'
+        'city': 'mycity',
+        'organization': 'my org',
     })
     user = f.save(commit=False)
     assert type(user.profile.image) == Image
@@ -197,7 +202,8 @@ def test_join(rf):
         'educator-email': 'email@example.com',
         'educator-password': '123123',
         'educator-confirm_password': '123123',
-        'educator-city': 'city'
+        'educator-city': 'city',
+        'educator-organization': 'my org',
     })
     request.session = mock.MagicMock()
     request.user = AnonymousUser()

--- a/profiles/views/educator.py
+++ b/profiles/views/educator.py
@@ -44,14 +44,14 @@ join = transaction.atomic(UserJoinView.as_view(
 @transaction.atomic
 def profile_edit(request):
     if request.method == 'POST':
-        form = forms.EducatorUserAndProfileForm(data=request.POST, instance=request.user, prefix='educator')
+        form = forms.EducatorUserAndProfileChangeForm(data=request.POST, instance=request.user, prefix='educator')
         if form.is_valid():
             form.save();
             messages.success(request, 'Profile has been updated.')
         else:
             messages.error(request, 'Correct errors below.')
     else:
-        form = forms.EducatorUserAndProfileForm(instance=request.user, prefix='educator')
+        form = forms.EducatorUserAndProfileChangeForm(instance=request.user, prefix='educator')
 
     return render(request, 'profiles/educator/profile_edit.html', {
         'form': form


### PR DESCRIPTION
It's not required when editing so that current educators can continue to edit their profiles without having to provide an org. Technically that means newer educators can delete the org they put in when signing up, but whatever.

No autocomplete yet.

<!---
@huboard:{"custom_state":"archived"}
-->
