### PR TITLE
removed the option to send fax from /underage page

### DIFF
--- a/profiles/templates/profiles/underage_student.html
+++ b/profiles/templates/profiles/underage_student.html
@@ -36,8 +36,6 @@
             Send to <a href="mailto:curiosity@iridescentlearning.org">curiosity@iridescentlearning.org</a>
             You can print the document, sign, scan or photograph, and email it to us or complete the consent form electronically using Adobe Acrobat Reader.
           </dd>
-          <dt>Via Fax</dt>
-          <dd>Fax to (888) 519-0108 with the title “COPPA Parent Consent”</dd>
           <dt>Via Mail</dt>
           <dd>Iridescent, 532 W. 22nd Street, Los Angeles, CA 90007</dd>
         </dl>


### PR DESCRIPTION
#1317 

Removed the sentences with the faxing option. Couldn't see this on my local page because it said I needed to be logged on...

<!---
@huboard:{"custom_state":"archived"}
-->
