### PR TITLE
Custom redirect after sign up

### DIFF
--- a/curiositymachine/tests/test_user_join_view.py
+++ b/curiositymachine/tests/test_user_join_view.py
@@ -1,0 +1,134 @@
+import pytest
+import mock
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.http import HttpResponseRedirect
+
+User = get_user_model()
+
+from profiles.models import Profile
+from ..views.generic import UserJoinView
+
+def test_redirects_logged_in_user(rf):
+    request = rf.get('/whatever')
+    user = User()
+    profile = Profile(user=user)
+    request.user = user
+    view = UserJoinView.as_view(logged_in_redirect='/redirect')
+    assert type(view(request)) == HttpResponseRedirect
+    assert view(request).url == '/redirect'
+
+def test_sets_source_in_initial_form_data(rf):
+    request = rf.get('/whatever')
+    request.user = AnonymousUser()
+
+    m = mock.MagicMock()
+    view = UserJoinView.as_view(form_class=m)
+    view(request, source='source')
+
+    args = m.call_args
+    assert 'initial' in args[1]
+    assert 'source' in args[1]['initial']
+    assert args[1]['initial']['source'] == 'source'
+
+def test_sets_source_in_form_data_from_url(rf):
+    request = rf.post('/whatever', {'source': None})
+    request.user = AnonymousUser()
+
+    class SubUserJoinView(UserJoinView):
+        def form_valid(self, form):
+            pass
+
+    m = mock.MagicMock()
+    view = SubUserJoinView.as_view(form_class=m)
+    view(request, source='source')
+
+    args = m.call_args
+    assert 'data' in args[1]
+    assert 'source' in args[1]['data']
+    assert args[1]['data']['source'] == 'source'
+
+def test_strips_source_if_not_in_url(rf):
+    request = rf.post('/whatever', {'source': 'source'})
+    request.user = AnonymousUser()
+
+    class SubUserJoinView(UserJoinView):
+        def form_valid(self, form):
+            pass
+
+    m = mock.MagicMock()
+    view = SubUserJoinView.as_view(form_class=m)
+    view(request)
+
+    args = m.call_args
+    assert 'data' in args[1]
+    assert 'source' not in args[1]['data']
+
+def test_templates(rf):
+    request = rf.get('/whatever')
+    request.user = AnonymousUser()
+
+    m = mock.MagicMock()
+    view = UserJoinView.as_view(form_class=m, prefix='usertype')
+
+    response = view(request)
+    assert response.template_name == ['profiles/usertype/join.html']
+
+    response = view(request, source='somesource')
+    assert response.template_name == ['profiles/sources/somesource/usertype/join.html', 'profiles/usertype/join.html']
+
+def test_redirects_to_success_url(rf):
+    request = rf.post('/whatever', {})
+    request.user = AnonymousUser()
+
+    class SubUserJoinView(UserJoinView):
+        def create_user(self, form):
+            return mock.MagicMock()
+
+    m = mock.MagicMock()
+    view = SubUserJoinView.as_view(form_class=m, prefix='usertype', success_url='/success')
+
+    response = view(request)
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == '/success'
+
+def test_redirects_to_welcome_url_from_form(rf):
+    request = rf.post('/join/thisone/', {'welcome': 'true'})
+    request.user = AnonymousUser()
+
+    class SubUserJoinView(UserJoinView):
+        def create_user(self, form):
+            return mock.MagicMock()
+
+    m = mock.MagicMock()
+    view = SubUserJoinView.as_view(form_class=m, success_url='/success')
+
+    response = view(request, source='thisone')
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == '/welcome/thisone'
+
+def test_puts_next_query_param_in_context(rf):
+    request = rf.get('/whatever?next=/next/')
+    request.user = AnonymousUser()
+
+    m = mock.MagicMock()
+    view = UserJoinView.as_view(form_class=m)
+    response = view(request)
+
+    assert "next" in response.context_data
+    assert response.context_data["next"] == "/next/"
+
+def test_redirects_to_next_param(rf):
+    request = rf.post('/whatever/', {'next': '/next/'})
+    request.user = AnonymousUser()
+
+    class SubUserJoinView(UserJoinView):
+        def create_user(self, form):
+            return mock.MagicMock()
+
+    m = mock.MagicMock()
+    view = SubUserJoinView.as_view(form_class=m, success_url='/success')
+
+    response = view(request)
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == '/next/'

--- a/curiositymachine/views/generic.py
+++ b/curiositymachine/views/generic.py
@@ -81,6 +81,17 @@ class UserJoinView(CreateView):
         return super(UserJoinView, self).dispatch(request, *args, **kwargs)
 
     def get_success_url(self):
+        redirect_to = self.request.POST.get(
+            'next',
+            self.request.GET.get('next', '')
+        )
+        redirect_is_safe = is_safe_url(
+            url=redirect_to,
+            require_https=self.request.is_secure()
+        )
+        if redirect_to and redirect_is_safe:
+            return redirect_to
+
         if self.welcome and self.source:
             return '/welcome/' + self.source
 
@@ -91,6 +102,7 @@ class UserJoinView(CreateView):
         context['source'] = self.source
         context['welcome'] = self.welcome
         context['action'] = self.request.path
+        context['next'] = self.request.POST.get('next', self.request.GET.get('next', ''))
         return context
 
     def get_initial(self):

--- a/profiles/templates/profiles/student/join.html
+++ b/profiles/templates/profiles/student/join.html
@@ -73,6 +73,9 @@
 
       {{ form.source }}
       {{ form.welcome }}
+      {% if next %}
+        <input type="hidden" name="next" value="{{ next }}" />
+      {% endif %}
       {{ form.non_field_errors }}
     </div>
   </div>

--- a/profiles/views/student.py
+++ b/profiles/views/student.py
@@ -21,12 +21,13 @@ class StudentUserJoinView(UserJoinView):
         if self.object.profile.is_underage():
             return reverse('profiles:underage_student')
         else:
-            return '/'
+            return super().get_success_url()
 
 join = transaction.atomic(StudentUserJoinView.as_view(
     form_class = StudentUserAndProfileForm,
     prefix = 'student',
-    logged_in_redirect = lazy(reverse, str)('profiles:home')
+    logged_in_redirect = lazy(reverse, str)('profiles:home'),
+    success_url = '/'
 ))
 
 @login_required


### PR DESCRIPTION
Groundwork for #1330

This adds the ability to have a custom redirect after signup (similarly to how login/logout works) by adding a `?next=` query param.

<!---
@huboard:{"custom_state":"archived"}
-->
