### PR TITLE
#1347 fix user creation problem from django upgrade

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -47,16 +47,12 @@ class UserAdminWithProfile(UserAdmin):
                     elif profile.is_mentor:
                         signals.completed_training.send(sender=profile.user, approver=request.user)
 
-    def get_form(self, request, obj=None, **kwargs):
-        request._obj_ = obj
-        return super().get_form(request, obj, **kwargs)
-
-    def get_formsets(self, request, obj=None):
+    def get_formsets_with_inlines(self, request, obj=None):
         for inline in self.get_inline_instances(request, obj):
             # hide ProfileInline in the add view
             if isinstance(inline, ProfileInline) and obj is None:
                 continue
-            yield inline.get_formset(request, obj)
+            yield inline.get_formset(request, obj), inline
 
 admin.site.unregister(User)
 admin.site.register(User, UserAdminWithProfile)

--- a/profiles/tests/decorators/test_membership_selection.py
+++ b/profiles/tests/decorators/test_membership_selection.py
@@ -1,7 +1,7 @@
 import pytest
 import mock
 from django.http import Http404
-from django.utils.timezone import now
+from django.utils.timezone import now, localtime
 from datetime import timedelta
 from ...decorators import MembershipSelection
 
@@ -132,7 +132,7 @@ def test_membership_selection_skips_inactive_memberships(rf):
 
 @pytest.mark.django_db
 def test_membership_selection_recently_expired(rf):
-    today = now().date()
+    today = localtime(now()).date()
     yesterday = today - timedelta(days=1)
     lastweek = today - timedelta(days=7)
     twomonthsago = today - timedelta(days=61)


### PR DESCRIPTION
Looks like `get_formsets` was dropped in 1.9 in favor of `get_formsets_with_inlines`.

<!---
@huboard:{"custom_state":"archived"}
-->
