### PR TITLE
#1369 put mentor notice on signup and remove profile selection option

### DIFF
--- a/curiositymachine/context_processors/__init__.py
+++ b/curiositymachine/context_processors/__init__.py
@@ -3,3 +3,4 @@ from .forms import *
 from .template_globals import *
 from .google_analytics import *
 from .staff_alerts import *
+from .emails import *

--- a/curiositymachine/context_processors/emails.py
+++ b/curiositymachine/context_processors/emails.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+def emails(request):
+    return {
+        'emails': {
+            'mentor_interest': settings.MENTOR_INTEREST_EMAIL,
+            'contact': settings.CONTACT_EMAIL,
+        }
+    }

--- a/curiositymachine/settings.py
+++ b/curiositymachine/settings.py
@@ -131,6 +131,7 @@ TEMPLATES = [
                 "curiositymachine.context_processors.feature_flags",
                 "curiositymachine.context_processors.template_globals",
                 "curiositymachine.context_processors.staff_alerts",
+                "curiositymachine.context_processors.emails",
             ],
             'loaders': [
                 'apptemplates.Loader',
@@ -287,6 +288,7 @@ EMAIL_INACTIVE_DAYS_MENTOR = os.environ.get("EMAIL_INACTIVE_DAYS_MENTOR", 7)
 EMAIL_INACTIVE_DAYS_STUDENT = os.environ.get("EMAIL_INACTIVE_DAYS_STUDENT", 14)
 PROGRESS_MONTH_ACTIVE_LIMIT = os.environ.get("PROGRESS_MONTH_ACTIVE_LIMIT", 2)
 CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", None)
+MENTOR_INTEREST_EMAIL = os.environ.get("MENTOR_INTEREST_EMAIL", CONTACT_EMAIL)
 REQUEST_A_MENTOR_LINK = os.environ.get("REQUEST_A_MENTOR_LINK", None)
 DOCEBO_MENTOR_URL = os.environ.get("DOCEBO_MENTOR_URL","http://www.iridescentuniversity.org/lms/")
 

--- a/curiositymachine/templates/account/signup.html
+++ b/curiositymachine/templates/account/signup.html
@@ -6,6 +6,8 @@
 
 {% block content %}
   <p>Already have an account? Then please <a href="{{ login_url }}">log in</a>.</p>
+  <p>Interested in mentoring? <a href="mailto:{{ emails.mentor_interest }}">Contact us</a>!
+  <hr/>
 
   <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
     {% csrf_token %}

--- a/curiositymachine/views/__init__.py
+++ b/curiositymachine/views/__init__.py
@@ -37,7 +37,7 @@ def csrf_failure_handler(request, reason=""):
 	ctx = {
         'title': _("Forbidden"),
         'main': _("Session Expired"),
-        'contact_email': settings.CONTACT_EMAIL if settings.CONTACT_EMAIL else "contactcm@mailinator.com",
+        'contact_email': settings.CONTACT_EMAIL,
         'reason': reason,
         'no_referer': reason == REASON_NO_REFERER,
         'no_referer1': _(

--- a/profiles/templates/profiles/choose_profile.html
+++ b/profiles/templates/profiles/choose_profile.html
@@ -20,18 +20,6 @@
     <a class="btn btn-primary" href="{{ student_url }}">I am a student</a>
   </div>
 
-  {% url "mentor" as mentor_url %}
-  <div class="card card-block mb-2">
-    <a href="{{ mentor_url }}">
-      <img class="float-xs-left" src="{% static "images/mentor.png" %}" alt="Mentor">
-    </a>
-    <h4>Mentor</h4>
-    <p>
-      guide students as they build engineering design challenges
-    </p>
-    <a class="btn btn-primary" href="{{ mentor_url }}">I am a mentor</a>
-  </div>
-
   {% url "educators:create_profile" as educator_url %}
   <div class="card card-block mb-2">
     <a href="{{ educator_url }}">


### PR DESCRIPTION
This fixes the mentor sign up thing in #1369. It also removes a hardcoded mailinator email that I thought was weird.

<!---
@huboard:{"custom_state":"archived"}
-->
