### PR TITLE
#1392 fix student signals and redirect underage to underage page on signup

### DIFF
--- a/students/__init__.py
+++ b/students/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'students.apps.StudentsConfig'

--- a/students/apps.py
+++ b/students/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 
-
 class StudentsConfig(AppConfig):
     name = 'students'
+
+    def ready(self):
+        import students.signals.handlers

--- a/students/tests/test_student.py
+++ b/students/tests/test_student.py
@@ -1,7 +1,23 @@
 import pytest
 from django.utils.timezone import now
+from profiles.factories import *
 from ..factories import *
+from ..models import *
 
 def test_user_type():
     assert StudentFactory.build().extra.user_type == 'student'
     assert StudentFactory.build(studentprofile__birthday=now()).extra.user_type == 'underage student'
+
+@pytest.mark.django_db
+def test_non_coppa_students_auto_approve():
+    user = UserFactory(extra__approved=False)
+    profile = StudentProfileFactory.build(user=user)
+    profile.save()
+    assert user.extra.approved
+
+@pytest.mark.django_db
+def test_underage_students_do_not_auto_approve():
+    user = UserFactory(extra__approved=False)
+    profile = StudentProfileFactory.build(user=user, underage=True)
+    profile.save()
+    assert not user.extra.approved

--- a/students/views.py
+++ b/students/views.py
@@ -15,7 +15,11 @@ only_for_student = only_for_role(UserRole.student)
 class CreateView(UserKwargMixin, CreateView):
     model = StudentProfile
     form_class = NewStudentProfileForm
-    success_url = lazy(reverse, str)("challenges:challenges")
+
+    def get_success_url(self):
+        if self.object.is_underage():
+            return reverse("students:underage")
+        return reverse("challenges:challenges")
 
 create = only_for_role(UserRole.none)(CreateView.as_view())
 


### PR DESCRIPTION
Students over 13 weren't being auto-approved. Fixed that, and students under 13 should now see the underage page after signing up instead of the challenges page.

<!---
@huboard:{"custom_state":"archived"}
-->
