### PR TITLE
#1440 novalidate forms for better required field indication

### DIFF
--- a/curiositymachine/templates/account/signup.html
+++ b/curiositymachine/templates/account/signup.html
@@ -9,7 +9,7 @@
   <p>Interested in mentoring? <a href="mailto:{{ emails.mentor_interest }}">Contact us</a>!
   <hr/>
 
-  <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
+  <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}" novalidate>
     {% csrf_token %}
     {% form_group form.username %}
     {% form_group form.email help_text="Children under 13 please provide a parent or guardian's email address"%}

--- a/curiositymachine/templatetags/bootstrap4.py
+++ b/curiositymachine/templatetags/bootstrap4.py
@@ -7,7 +7,7 @@ def form_group(field, **kwargs):
     context = {
         "field": field,
         "field_class": "form-control",
-        "help_text_classes": kwargs.get("help_text_classes", "text-muted")
+        "help_text_classes": kwargs.get("help_text_classes", "text-muted"),
     }
     context.update(kwargs)
     return context

--- a/profiles/templates/profiles/profile_form.html
+++ b/profiles/templates/profiles/profile_form.html
@@ -25,7 +25,7 @@
           <h4>{% block card_title %}Profile Info{% endblock %}</h4>
         </div>
         <div class="card-block">
-          <form action="{% block action %}{% endblock %}" method="POST">
+          <form action="{% block action %}{% endblock %}" method="POST" novalidate>
             {% csrf_token %}
             {% block fields %}
               {% block avatar %}


### PR DESCRIPTION
Some forms are mostly required and some are mostly optional, so I think it's best to let django validation handle the messaging by turning off browser required field validation.

<!---
@huboard:{"custom_state":"archived"}
-->
