### PR TITLE
make foreign keys that load too slow into raw_id_fields in admin

### DIFF
--- a/parents/admin.py
+++ b/parents/admin.py
@@ -10,6 +10,7 @@ class ParentConnectionAdmin(admin.ModelAdmin):
         'parent_profile__user__email',
         'child_profile__user__email'
     ]
+    raw_id_fields = ['parent_profile', 'child_profile']
 
     def parent(self, obj):
         return obj.parent_profile.user.username

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -36,16 +36,26 @@ class UserExtraInline(admin.StackedInline):
 
 class EducatorProfileInline(admin.StackedInline):
     model = EducatorProfile
+    raw_id_fields = ['image']
 
 class MentorProfileInline(admin.StackedInline):
     model = MentorProfile
+    raw_id_fields = [
+        'image',
+        'about_me_image',
+        'about_research_image',
+        'about_me_video',
+        'about_research_video',
+    ]
 
 class ParentProfileInline(admin.StackedInline):
     model = ParentProfile
+    raw_id_fields = ['image']
     min_num = 1
 
 class StudentProfileInline(admin.StackedInline):
     model = StudentProfile
+    raw_id_fields = ['image']
 
 class CMUserChangeForm(UserChangeForm):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
`ParentConnection`s don't have the magnifying glass thing because parent and student profiles don't have their own admins but it shouldn't be a problem for now.

<!---
@huboard:{"custom_state":"archived"}
-->
