### PR TITLE
fix filename/file case discrepancy and normalize to lowercase

### DIFF
--- a/curiositymachine/templates/curiositymachine/index.html
+++ b/curiositymachine/templates/curiositymachine/index.html
@@ -73,10 +73,10 @@
         <h2 class="mt-3">and leaders of innovative technology</h2>
         <div class="logos">
           <a href="https://www.google.com/" class="a-borderless">
-            <img src="{% static 'images/logos/google-logo.PNG' %}" alt="Google logo">
+            <img src="{% static 'images/logos/google-logo.png' %}" alt="Google logo">
           </a>
           <a href="http://www.nvidia.com/page/home.html" class="a-borderless">
-            <img src="{% static 'images/logos/nvidia-logo.PNG' %}" alt="NVIDIA logo">
+            <img src="{% static 'images/logos/nvidia-logo.png' %}" alt="NVIDIA logo">
           </a>
           <a href="https://www.gm.com/" class="a-borderless">
             <img src="{% static 'images/logos/gm-logo.jpg' %}" alt="General Motors logo">


### PR DESCRIPTION
@rsgonzal #1516 didn't work in staging because the filename ended in `.png` but was in the HTML as `.PNG`. I think local environments handle this fine (it considers them the same) but Heroku *does not*, so the image wasn't found. 

This fixes it for the google logo, and changes the nvidia logo to be lowercase both in HTML and filename.