### PR TITLE
added link for ai mentors on sign up and corporate page

### DIFF
--- a/curiositymachine/templates/account/signup.html
+++ b/curiositymachine/templates/account/signup.html
@@ -11,7 +11,7 @@
 
 {% block content %}
   <p>Already have an account? Then please <a href="{{ login_url }}">log in</a>.</p>
-  <p>Interested in mentoring? <a href="mailto:{{ emails.mentor_interest }}">Contact us</a>!
+  <p>Interested in mentoring? <a href="https://docs.google.com/forms/d/e/1FAIpQLSflWTQ1DHmAsdzKU6ZrmCTINPqHTvym15apTqAF5Dmb80cZfw/viewform?usp=sf_link">Tell us here</a>!
   <hr/>
 
   {% if membership %}

--- a/curiositymachine/templates/curiositymachine/pages/about-partnership.html
+++ b/curiositymachine/templates/curiositymachine/pages/about-partnership.html
@@ -57,6 +57,6 @@
   <div class="sign-up-panel py-3">
     <h2>Be a part of the Artificial Intelligence Family Challenge</h2>
     <a href="{% url 'aichallenge' %}" class="btn btn-red-secondary text-uppercase">Learn More</a>
-    <a href="mailto:curiosity@iridescentlearning.org" class="btn btn-red-secondary text-uppercase" target="_blank">Contact</a>
+    <a href="https://docs.google.com/forms/d/e/1FAIpQLSflWTQ1DHmAsdzKU6ZrmCTINPqHTvym15apTqAF5Dmb80cZfw/viewform?usp=sf_link" class="btn btn-red-secondary text-uppercase" target="_blank">Sign up to Mentor!</a>
   </div>
 {% endblock %}


### PR DESCRIPTION
fundraising needed a place to send mentors to sign up. Replaced link to contact us on sign up page and on the corporate partners page