### PR TITLE
add ai challenge options sketch to chooser

### DIFF
--- a/curiositymachine/settings.py
+++ b/curiositymachine/settings.py
@@ -294,6 +294,7 @@ AICHALLENGE_STAGES = {
         "units": [int(i) for i in os.getenv("AICHALLENGE_STAGE_2_UNITS", "").split(',') if i],
     },
 }
+AICHALLENGE_COACH_MEMBERSHIP_ID=2
 
 MENTOR_RELATIONSHIP_MANAGERS = os.getenv("MENTOR_RELATIONSHIP_MANAGERS", '').split(',') if os.getenv("MENTOR_RELATIONSHIP_MANAGERS") else []
 NOTIFICATION_RECIPIENTS = os.getenv("NOTIFICATION_RECIPIENTS").split(',') if os.getenv("NOTIFICATION_RECIPIENTS") else []

--- a/educators/urls.py
+++ b/educators/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     url(r'^home/guides/$', guides, name='guides'),
     url(r'^data/impact_survey/$', impact_data, name='update_impact_survey'),
     url(r'^data/progress_posts/$', comments, name='progress_graph_data'),
+    url(r'^coach/$', coach, name='create_coach'),
 ]

--- a/profiles/templates/profiles/choose_profile.html
+++ b/profiles/templates/profiles/choose_profile.html
@@ -6,6 +6,16 @@
 {% block pagehead %}Sign Up{% endblock %}
 
 {% block content %}
+  {% if flags.enable_ai_challenge_profile_options %}
+  <div class="card card-block mb-3">
+    <h2>Join the AI Family Challenge!</h2>
+    <p>Chicory barista caramelization single shot latte saucer milk spoon. Iced single shot variety affogato doppio arabica java french press black and medium. Single shot half and half, affogato coffee percolator, in sugar carajillo decaffeinated filter. Acerbic iced galão roast to go café au lait beans acerbic foam.</p>
+    <a class="btn btn-primary my-2" href="{% url "families:create_profile" %}">Family account</a>
+    <a class="btn btn-primary my-2" href="{% url "educators:create_coach" %}">Coach account</a>
+    <p class="mt-2">Not interested? Choose one of the other ways to join Curiosity Machine below.</p>
+  </div>
+  {% endif %}
+
   <h2>Join as a:</h2>
 
   {% url "students:create_profile" as student_url %}


### PR DESCRIPTION
Adds AI challenge sign up options to the top of the profile chooser page, hidden behind the feature flag `ENABLE_AI_CHALLENGE_PROFILE_OPTIONS`. Also needs `AICHALLENGE_COACH_MEMBERSHIP_ID` pointing to the membership to dump coaches into.

<!---
@huboard:{"custom_state":"archived"}
-->
