### PR TITLE
#1563 student underage page redirects approved users

### DIFF
--- a/curiositymachine/decorators.py
+++ b/curiositymachine/decorators.py
@@ -14,6 +14,15 @@ def anonymous_only(view):
             return view(request, *args, **kwargs)
     return inner
 
+def unapproved_only(view):
+    @wraps(view)
+    def inner(request, *args, **kwargs):
+        if request.user.is_authenticated() and not request.user.extra.approved:
+            return view(request, *args, **kwargs)
+        else:
+            return HttpResponseRedirect(reverse('root'))
+    return inner
+
 def mentor_or_current_user(view):
     @wraps(view)
     def inner(request, challenge_id, username, *args, **kwargs):

--- a/students/tests/test_student.py
+++ b/students/tests/test_student.py
@@ -21,3 +21,18 @@ def test_underage_students_do_not_auto_approve():
     profile = StudentProfileFactory.build(user=user, underage=True)
     profile.save()
     assert not user.extra.approved
+
+@pytest.mark.django_db
+def test_underage_only_viewable_unapproved(client):
+    user = StudentFactory(password="password", extra__approved=False)
+    client.login(username=user.username, password="password")
+
+    response = client.get('/student/underage/')
+    assert response.status_code == 200
+
+    user.extra.approved = True
+    user.extra.save()
+
+    response = client.get('/student/underage/')
+    assert response.status_code == 302
+    

--- a/students/views.py
+++ b/students/views.py
@@ -1,5 +1,6 @@
 from allauth.account.models import EmailAddress
 from challenges.models import Progress, Favorite, Challenge
+from curiositymachine.decorators import unapproved_only
 from django.contrib import messages
 from django.shortcuts import Http404
 from django.urls import reverse
@@ -75,4 +76,4 @@ class HomeView(TemplateView):
 
 home = only_for_student(HomeView.as_view())
 
-underage = TemplateView.as_view(template_name='students/underage.html')
+underage = unapproved_only(TemplateView.as_view(template_name='students/underage.html'))


### PR DESCRIPTION
I can't tell you how many times I've set up an underage student and sat there refreshing the underage page wondering why my user wasn't approved.

<!---
@huboard:{"custom_state":"archived"}
-->
