### PR TITLE
#1564 only clean username when it has changed in admin

### DIFF
--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -61,8 +61,9 @@ class StudentProfileInline(admin.StackedInline):
 class CMUsernameMixin():
     def clean_username(self):
         value = self.cleaned_data["username"]
-        # enforce some allauth validation, uniqueness in particular
-        value = get_adapter().clean_username(value)
+        if self.has_changed() and "username" in self.changed_data:
+            # enforce some allauth validation, uniqueness in particular
+            value = get_adapter().clean_username(value)
         return value
 
 class CMUserChangeForm(CMUsernameMixin, UserChangeForm):


### PR DESCRIPTION
The allauth adapter's `clean_username` isn't smart enough to not detect a username collision with itself, so we only want to run it when the admin user has changed the username.

<!---
@huboard:{"custom_state":"archived"}
-->
