### PR TITLE
#1638 allow people to click coach button more than once

### DIFF
--- a/educators/views.py
+++ b/educators/views.py
@@ -314,8 +314,7 @@ class CoachView(RedirectView):
         self.membership_id = settings.AICHALLENGE_COACH_MEMBERSHIP_ID
 
     def get(self, request, *args, **kwargs):
-        member = Member(user=request.user, membership_id=self.membership_id)
-        member.save()
+        member, created = Member.objects.get_or_create(user=request.user, membership_id=self.membership_id)
         return super().get(request, *args, **kwargs)
 
 coach = CoachView.as_view()


### PR DESCRIPTION
If someone clicks the coach button, uses the back button, then clicks it again, this will bring them back to the educator profile screen instead of an error.

<!---
@huboard:{"custom_state":"archived"}
-->
