### PR TITLE
#1655 add logging on survey updating

### DIFF
--- a/surveys/jobs.py
+++ b/surveys/jobs.py
@@ -25,6 +25,7 @@ def update_status(survey_id, response_id):
     if token:
         sr = SurveyResponse.objects.filter(id=token).first()
         if sr:
+            logger.info("SurveyResponse %s=%s moving to %s", token_var, token, new_status)
             status = ResponseStatus[new_status.upper()]
             Updating(sr, status).run()
         else:

--- a/surveys/management/commands/surveymonkey.py
+++ b/surveys/management/commands/surveymonkey.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from ...api import Surveymonkey
+from ...jobs import update_status
 import json
 import pprint
 
@@ -101,6 +102,24 @@ class Command(BaseCommand):
             help="JSON data to POST for webhook creation"
         )
 
+        update = subparsers.add_parser(
+            'update',
+            help='run update job',
+            description="Run update job for a survey response; run or re-run update job otherwise triggered by webhook"
+        )
+        update.add_argument(
+            "-s", "--survey-id",
+            action="store",
+            dest="survey_id",
+            help="Survey id"
+        )
+        update.add_argument(
+            "-r", "--response-id",
+            action="store",
+            dest="response_id",
+            help="Survey response id to update"
+        )
+
         curl = subparsers.add_parser(
             'curl',
             help='example curls statements',
@@ -164,6 +183,9 @@ class Command(BaseCommand):
         path = "webhooks/%s" % options.get('id')
         res = self.api.get(path)
         self.pp.pprint(res.json())
+
+    def handle_update(self, **options):
+        update_status(options.get('survey_id'), options.get('response_id'))
 
     def handle_curl(self, **options):
         token = settings.SURVEYMONKEY_ACCESS_TOKEN

--- a/surveys/updating.py
+++ b/surveys/updating.py
@@ -37,6 +37,7 @@ class Updating:
 
         status = survey_response.status
 
+        logger.info("Updating %s -> %s", survey_response, new_status)
         if status == new_status:
             return survey_response
 

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -35,6 +35,7 @@ class SurveyResponseHook(View):
                 survey_id = data['filter_id']
                 response_id = data['object_id']
                 django_rq.enqueue(update_status, survey_id, response_id)
+                logger.info("Update job queued for survey_id=%s response_id=%s", survey_id, response_id)
             except JSONDecodeError:
                 logger.error("Error decoding webhook request body as JSON: %s" % request.body)
                 raise


### PR DESCRIPTION
This adds some logging to make it easier to track what should be happening in regards to survey statuses getting updated, and a command to rerun the update job.

<!---
@huboard:{"custom_state":"archived"}
-->
