### PR TITLE
#1663 track profile creation in google analytics

### DIFF
--- a/curiositymachine/allauth_adapter.py
+++ b/curiositymachine/allauth_adapter.py
@@ -1,4 +1,5 @@
 from allauth.account.adapter import DefaultAccountAdapter
+from curiositymachine.context_processors.google_analytics import add_event
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import MultipleObjectsReturned
@@ -36,3 +37,8 @@ class AllAuthAdapter(DefaultAccountAdapter):
             return super().authenticate(request, **credentials)
         except MultipleObjectsReturned:
             logger.error("Duplicate usernames found on login for %s:" % credentials.get("username"), exc_info=True)
+
+    def save_user(self, request, user, form, commit=True):
+        user = super().save_user(request, user, form, commit=commit)
+        add_event(request, "account", "create")
+        return user

--- a/curiositymachine/context_processors/google_analytics.py
+++ b/curiositymachine/context_processors/google_analytics.py
@@ -7,7 +7,7 @@ __all__ = ['google_analytics']
 
 SESSION_KEY = '_ga_events'
 
-def add_event(request, category, action, label):
+def add_event(request, category, action, label=""):
     if SESSION_KEY not in request.session:
         request.session[SESSION_KEY] = []
     request.session[SESSION_KEY].append({
@@ -15,6 +15,9 @@ def add_event(request, category, action, label):
         'action': action,
         'label': label
     })
+
+def get_events(request):
+    return request.session.pop(SESSION_KEY, [])
 
 def google_analytics(request):
     if not request.user.is_authenticated():
@@ -46,8 +49,8 @@ def google_analytics(request):
         free_user = "Membership" if request.user.extra.in_active_membership else "Free"
         membership_grouping = "-".join([str(id) for id in request.user.membership_set.filter(is_active=True).order_by('id').values_list('id', flat=True)])
 
-    def get_events():
-        return request.session.pop(SESSION_KEY, [])
+    def ga_events():
+        return get_events(request)
 
     return {
         'ga_code': settings.GA_CODE,
@@ -55,6 +58,6 @@ def google_analytics(request):
         'ga_user_id': userid,
         'ga_dimension_free_user': free_user,
         'ga_membership_grouping': membership_grouping,
-        'ga_events': get_events,
+        'ga_events': ga_events,
     }
 

--- a/profiles/tests/test_edit_profile_mixin.py
+++ b/profiles/tests/test_edit_profile_mixin.py
@@ -1,0 +1,46 @@
+from curiositymachine.context_processors.google_analytics import get_events
+from django.views.generic import *
+from ..factories import *
+from ..forms import *
+from ..views import *
+import mock
+import pytest
+
+def test_adds_event_on_create(rf):
+    TestForm = mock.Mock()
+    TestForm().get_role().name = 'role name'
+
+    class TestCreateView(EditProfileMixin, CreateView):
+        form_class = TestForm
+
+    view = TestCreateView.as_view()
+
+    req = rf.post('/whatever', {})
+    req.user = UserFactory.build()
+    req.session = {}
+
+    view(req)
+
+    evts = get_events(req)
+    assert len(evts) == 1
+    assert evts[0] == {"category": "profile", "action": "create", "label": "role name"}
+
+def test_no_event_on_update(rf):
+    TestForm = mock.Mock()
+    TestForm().get_role().name = 'role name'
+
+    class TestEditView(EditProfileMixin, UpdateView):
+        form_class = TestForm
+        queryset = mock.MagicMock()
+
+    view = TestEditView.as_view()
+
+    req = rf.post('/whatever', {})
+    req.user = UserFactory.build()
+    req.session = {}
+
+    view(req, pk=1)
+
+    evts = get_events(req)
+    assert len(evts) == 0
+

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -1,4 +1,5 @@
 from allauth.account.models import EmailAddress
+from curiositymachine.context_processors.google_analytics import add_event
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
@@ -37,3 +38,11 @@ class EditProfileMixin():
             email=EmailAddress.objects.get_primary(self.request.user),
             **kwargs
         )
+
+    def _is_create(self):
+        return not self.object
+
+    def form_valid(self, form):
+        if self._is_create():
+            add_event(self.request, "profile", "create", form.get_role().name)
+        return super().form_valid(form)


### PR DESCRIPTION
This should do it for all profile types. There will be account/create events and profile/create/\<role\> events.

<!---
@huboard:{"custom_state":"archived"}
-->
