### PR TITLE
#1698 change to correct membership when clicking on notification

### DIFF
--- a/challenges/tests/test_progressing.py
+++ b/challenges/tests/test_progressing.py
@@ -134,8 +134,9 @@ def test_progress_educators_looks_up_connected_educators():
     student = StudentFactory()
     progress=ProgressFactory(owner=student)
     ed = EducatorFactory()
-    MembershipFactory(members=[student, ed], challenges=[progress.challenge])
+    m = MembershipFactory(members=[student, ed], challenges=[progress.challenge])
     assert [pe.user.id for pe in ProgressEducators(progress).educators] == [ed.id]
+    assert [pe.membership.id for pe in ProgressEducators(progress).educators] == [m.id]
 
 @pytest.mark.django_db
 def test_progress_educators_skips_memberships_without_relevant_challenge():
@@ -154,13 +155,14 @@ def test_progress_educators_skips_inactive_memberships():
     assert not ProgressEducators(progress).educators
 
 @pytest.mark.django_db
-def test_progress_educators_counts_educators_connected_in_multiple_ways_only_once():
+def test_progress_educators_counts_educators_connected_in_multiple_ways():
     student = StudentFactory()
     progress=ProgressFactory(owner=student)
     ed = EducatorFactory()
-    MembershipFactory(members=[student, ed], challenges=[progress.challenge])
-    MembershipFactory(members=[student, ed], challenges=[progress.challenge])
-    assert [pe.user.id for pe in ProgressEducators(progress).educators] == [ed.id]
+    m1 = MembershipFactory(members=[student, ed], challenges=[progress.challenge])
+    m2 = MembershipFactory(members=[student, ed], challenges=[progress.challenge])
+    assert [pe.user.id for pe in ProgressEducators(progress).educators] == [ed.id, ed.id]
+    assert set([pe.membership.id for pe in ProgressEducators(progress).educators]) == set([m1.id, m2.id])
 
 @pytest.mark.django_db
 def test_progress_educators_dispatches_to_each_educator():

--- a/curiositymachine/settings.py
+++ b/curiositymachine/settings.py
@@ -281,6 +281,8 @@ LOGGING = {
     },
 }
 
+NOTIFICATIONS_USE_JSONFIELD = True
+
 # Additional app config
 GA_CODE = os.environ.get("GA_CODE", None)
 

--- a/curiositymachine/templates/curiositymachine/templatetags/cm_notifications/notification.html
+++ b/curiositymachine/templates/curiositymachine/templatetags/cm_notifications/notification.html
@@ -1,0 +1,7 @@
+<i class="indicator {{ indicator_class }}"></i>
+<a href="{{ url }}">
+  {{ text }}
+</a>
+<small class="timesince">
+{{ timesince }} ago
+</small>

--- a/curiositymachine/templatetags/cm_notifications.py
+++ b/curiositymachine/templatetags/cm_notifications.py
@@ -1,0 +1,35 @@
+from django import template
+from django.urls import reverse
+from urllib.parse import urlunparse
+
+register = template.Library()
+
+@register.inclusion_tag('curiositymachine/templatetags/cm_notifications/notification.html')
+def cm_notification(n, **kwargs):
+    if n.verb == 'posted':
+        text = "%s commented on %s" % (n.actor, n.target.challenge.name)
+        path = reverse("educators:conversation", kwargs={
+            "student_id": n.target.owner.id,
+            "challenge_id": n.target.challenge.id
+        })
+        fragment = "comment-%s" % n.action_object.id
+    elif n.verb == 'completed':
+        text = "%s %s %s" % (n.actor, n.verb, n.action_object.challenge.name)
+        path = reverse("educators:conversation", kwargs={
+            "student_id": n.action_object.owner.id,
+            "challenge_id": n.action_object.challenge.id
+        })
+        fragment = "content"
+
+    query = ""
+    if "membership_id" in n.data:
+        query = "m=%d" % n.data['membership_id']
+
+
+    context = {
+        "indicator_class": "indicator-unread" if n.unread else "indicator-read",
+        "url": urlunparse(('', '', path, '', query, fragment)),
+        "text": text,
+        "timesince": n.timesince,
+    }
+    return context

--- a/educators/progressing.py
+++ b/educators/progressing.py
@@ -2,12 +2,11 @@ from challenges.progressing import BaseActor
 from notifications.signals import notify
 
 class ProgressEducator(BaseActor):
-
     def on_progress_complete(self, progress):
-        notify.send(progress.owner, recipient=self.user, verb="completed", action_object=progress)
+        notify.send(progress.owner, recipient=self.user, verb="completed", action_object=progress, membership_id=self.membership.id)
 
     def on_comment_posted(self, progress, comment):
         pass # can't happen, yet
 
     def on_comment_received(self, progress, comment):
-        notify.send(comment.user, recipient=self.user, verb="posted", action_object=comment, target=progress)
+        notify.send(comment.user, recipient=self.user, verb="posted", action_object=comment, target=progress, membership_id=self.membership.id)

--- a/educators/templates/educators/dashboard/_navigation.html
+++ b/educators/templates/educators/dashboard/_navigation.html
@@ -33,7 +33,7 @@
             units &amp; guides
           </a>
         </li>
-        {% if membership_selection.selected.listed_members and flags.enable_educator_feedback %}
+        {% if flags.enable_educator_feedback %}
         <li class="nav-item {% ifactive "educators:activity" "active-nav" %}">
           <a class="nav-link" href="{% url 'educators:activity' %}">
             recent activity

--- a/educators/templates/educators/dashboard/activity.html
+++ b/educators/templates/educators/dashboard/activity.html
@@ -1,4 +1,5 @@
 {% extends "educators/dashboard/base.html" %}
+{% load cm_notifications %}
 
 {% block content %}
   {% include 'educators/dashboard/_navigation.html' %}
@@ -10,19 +11,7 @@
     <li class="list-group-item disabled">{{ day|date:"DATE_FORMAT" }}</li>
     {% for notification in activity %}
     <li class="list-group-item">
-      <i class="indicator {% if notification.unread %}indicator-unread{% else %}indicator-read{% endif %}"></i>
-      {% if notification.verb == 'posted' %}
-      <a href="{% url "educators:conversation" student_id=notification.target.owner.id challenge_id=notification.target.challenge.id %}#comment-{{notification.action_object.id}}">
-        {{ notification.actor }} commented on {{ notification.target.challenge.name }}
-      </a>
-      {% elif notification.verb == 'completed' %}
-      <a href="{% url "educators:conversation" student_id=notification.action_object.owner.id challenge_id=notification.action_object.challenge.id %}#content">
-        {{ notification.actor }} {{ notification.verb }} {{ notification.action_object.challenge.name }}
-      </a>
-      {% endif %}
-      <small class="timesince">
-        {{ notification.timesince }} ago
-      </small>
+      {% cm_notification notification %}
     </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
With this PR, the "Recent Activity" tab shows for all educators, and for educators in multiple memberships, it will change them to the correct membership if they click on a notification for a different membership than what is currently selected.

<!---
@huboard:{"custom_state":"archived"}
-->
