### PR TITLE
#1700 add family post survey after 5 aifc dcs

### DIFF
--- a/curiositymachine/settings.py
+++ b/curiositymachine/settings.py
@@ -116,6 +116,7 @@ MIDDLEWARE_CLASSES = (
     'curiositymachine.middleware.LastActiveMiddleware',
     'curiositymachine.middleware.FirstLoginMiddleware',
     'families.middleware.SignUpPrerequisitesMiddleware',
+    'families.middleware.PostSurveyMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
 )
 
@@ -303,6 +304,7 @@ AICHALLENGE_STAGES = {
 }
 AICHALLENGE_COACH_MEMBERSHIP_ID=os.getenv("AICHALLENGE_COACH_MEMBERSHIP_ID", "")
 AICHALLENGE_FAMILY_PRE_SURVEY_ID=os.getenv("AICHALLENGE_FAMILY_PRE_SURVEY_ID", "")
+AICHALLENGE_FAMILY_POST_SURVEY_ID=os.getenv("AICHALLENGE_FAMILY_POST_SURVEY_ID", "")
 AICHALLENGE_FAMILY_CONSENT_TEMPLATE_ID=os.getenv("AICHALLENGE_FAMILY_CONSENT_TEMPLATE_ID", "")
 
 MENTOR_RELATIONSHIP_MANAGERS = os.getenv("MENTOR_RELATIONSHIP_MANAGERS", '').split(',') if os.getenv("MENTOR_RELATIONSHIP_MANAGERS") else []

--- a/families/middleware.py
+++ b/families/middleware.py
@@ -2,7 +2,8 @@ from curiositymachine.middleware import whitelist_regex, whitelisted
 from django.conf import settings
 from django.http import HttpResponseRedirect, HttpResponse
 from surveys import get_survey
-from .views import prereq_interruption
+from .aichallenge import Stage
+from .views import prereq_interruption, postsurvey_interruption
 
 class SignUpPrerequisitesMiddleware:
     """
@@ -20,3 +21,24 @@ class SignUpPrerequisitesMiddleware:
         ):
             return prereq_interruption(request)
 
+class PostSurveyMiddleware:
+    """
+    Middleware that interrupts at the appropriate point to prompt users to take post-survey.
+    """
+    def process_view(self, request, view, view_args, view_kwargs):
+        if (
+            request.user.is_authenticated()
+            and request.user.extra.is_family
+            and not (
+                whitelisted(view, 'public', 'maybe_public')
+                or whitelist_regex.match(request.path.lstrip('/'))
+            )
+        ):
+            stage1 = Stage.from_config(1, user=request.user)
+            stage2 = Stage.from_config(2, user=request.user)
+            if stage1.stats["completed"] + stage2.stats["completed"] >= 5:
+                post_survey = get_survey(settings.AICHALLENGE_FAMILY_POST_SURVEY_ID)
+                if post_survey.active:
+                    response = post_survey.response(request.user)
+                    if not response.completed:
+                        return postsurvey_interruption(request)

--- a/families/templates/families/post_survey.html
+++ b/families/templates/families/post_survey.html
@@ -1,0 +1,14 @@
+{% extends "curiositymachine/layout/base.html" %}
+
+{% block content %}
+  <div class="jumbotron-blue jumbotron-fluid text-xs-center">
+    <h1>Take survey plz...</h1>
+  </div>
+  <div class="container mb-3">
+    <div class="row">
+      <div class="col-md-8 offset-md-2">
+        Hey buddy. <a href="{{postsurvey.url }}">Take a survey.</a>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/families/views.py
+++ b/families/views.py
@@ -119,6 +119,24 @@ class PrereqInterruptionView(TemplateView):
 
 prereq_interruption = only_for_family(PrereqInterruptionView.as_view())
 
+class PostSurveyInterruptionView(TemplateView):
+    template_name = "families/post_survey.html"
+
+    def post(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+    def put(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        postsurvey = get_survey(settings.AICHALLENGE_FAMILY_POST_SURVEY_ID)
+        return super().get_context_data(
+            **kwargs,
+            postsurvey=postsurvey.response(self.request.user),
+        )
+
+postsurvey_interruption = only_for_family(PostSurveyInterruptionView.as_view())
+
 class EditEmailView(EditProfileMixin, UpdateView):
     model = FamilyProfile
     form_class = FamilyEmailForm

--- a/surveys/__init__.py
+++ b/surveys/__init__.py
@@ -1,11 +1,19 @@
 from django.conf import settings
 
 class Survey:
+
+    defaults = {
+        "ACTIVE": False
+    }
+
     def __init__(self, id, *args, **kwargs):
         self.id = id
 
     def __getattr__(self, name):
-        return getattr(settings, "SURVEY_%s_%s" % (self.id, name.upper()))
+        name = name.upper()
+        if name in self.defaults:
+            return getattr(settings, "SURVEY_%s_%s" % (self.id, name), self.defaults[name])
+        return getattr(settings, "SURVEY_%s_%s" % (self.id, name))
 
     def response(self, user):
         from .models import SurveyResponse

--- a/surveys/tests/test_survey.py
+++ b/surveys/tests/test_survey.py
@@ -2,8 +2,15 @@ import mock
 import pytest
 from .. import get_survey
 
+def test_unconfigured_survey_is_inactive():
+    with mock.patch('surveys.settings', autospec=True) as settings:
+        settings.SURVEY_123_LINK = "link"
+
+        assert not get_survey("123").active
+        assert not get_survey("456").active
+
 def test_get_survey():
-    with mock.patch('surveys.settings') as settings:
+    with mock.patch('surveys.settings', autospec=True) as settings:
         settings.SURVEY_123_ACTIVE = "1"
         settings.SURVEY_123_LINK = "link"
 


### PR DESCRIPTION
Also changes surveys a little so if they're totally unconfigured, `.active` will be False instead of causing an error.

<!---
@huboard:{"custom_state":"archived"}
-->
