### PR TITLE
#1980 set lessons contentgroup

### DIFF
--- a/lessons/templates/lessons/page.html
+++ b/lessons/templates/lessons/page.html
@@ -3,6 +3,14 @@
 {% block body-id %}lesson-page{% endblock %}
 {% block body-classes %}lesson-pages{% endblock %}
 
+{% block js %}
+  <script>
+    {% if ga_code %}
+    ga('set', 'contentGroup3', '{{ lesson.title }}');
+    {% endif %}
+  </script>
+{% endblock %}
+
 {% block content %}
 
   <div class="container">


### PR DESCRIPTION
We can't tell by URL which lesson a person is looking at if they're logged in, but this should give us a way to see lesson traffic in GA grouped by lesson, not progress, which might be helpful to detect dropoff.

<!---
@huboard:{"custom_state":"archived"}
-->
