### PR TITLE
#2107 add survey filter by survey id

### DIFF
--- a/surveys/admin.py
+++ b/surveys/admin.py
@@ -1,11 +1,23 @@
 from django.contrib import admin
 from enumfields.admin import EnumFieldListFilter
+from . import get_survey
 from .models import *
 from .updating import Updating
 
+class SurveyNameFilter(admin.SimpleListFilter):
+    title = "Name"
+    parameter_name = 'name'
+
+    def lookups(self, request, model_admin):
+        ids = SurveyResponse.objects.distinct('survey_id').values_list('survey_id', flat=True)
+        return ((id, "%s - %s" % (id, getattr(get_survey(id), "name", "n/a"))) for id in ids)
+
+    def queryset(self, request, queryset):
+        return queryset.filter(survey_id=self.value())
+
 class SurveyResponseAdmin(admin.ModelAdmin):
     list_display = ['id', 'survey_id', 'user', 'status', 'created_at', 'updated_at']
-    list_filter = [('status', EnumFieldListFilter)]
+    list_filter = [('status', EnumFieldListFilter), SurveyNameFilter]
     readonly_fields = ['id', 'survey_id', 'user', 'created_at', 'updated_at']
     search_fields = ['id', 'survey_id', 'user__username']
     ordering = ('-created_at',)


### PR DESCRIPTION
This adds a filter to the SurveyResponse admin page where you can filter by survey id, and it optionally looks up a name from config so we can pair ids with a name like "pre" or "post" or whatever would be helpful. 

<!---
@huboard:{"custom_state":"archived"}
-->
