### PR TITLE
hid mentor community page from nav bar

### DIFF
--- a/curiositymachine/templates/curiositymachine/layout/about_pg_layout.html
+++ b/curiositymachine/templates/curiositymachine/layout/about_pg_layout.html
@@ -36,15 +36,6 @@
       </li>
       <li class="nav-item">
         <a
-          class="nav-link"
-          href="{% url 'mentors:list' %}"
-          id="mentor-community-page"
-        >
-          Mentor Community
-        </a>
-      </li>
-      <li class="nav-item">
-        <a
           class="nav-link {% if active_nav == 'community-guidelines' %}active{% endif %}"
           href="/community-guidelines"
           id="community-guidelines-about-page-nav"


### PR DESCRIPTION
we don't want to show the mentor community page anymore. especially since it might go away when we turn mentors into educators.

<!---
@huboard:{"custom_state":"archived"}
-->
