### PR TITLE
better error reporting on surveys

### DIFF
--- a/educators/tests/test_educator.py
+++ b/educators/tests/test_educator.py
@@ -24,6 +24,7 @@ def test_full_coach_access_with_active_survey(settings):
     coaches = MembershipFactory()
     settings.AICHALLENGE_COACH_MEMBERSHIP_ID = coaches.id
     settings.AICHALLENGE_COACH_PRE_SURVEY_ID = '987'
+    settings.SURVEY_987_LINK = 'x'
     settings.SURVEY_987_ACTIVE = 1
 
     notcoach = EducatorFactory()
@@ -45,6 +46,7 @@ def test_full_coach_access_with_inactive_survey(settings):
     coaches = MembershipFactory()
     settings.AICHALLENGE_COACH_MEMBERSHIP_ID = coaches.id
     settings.AICHALLENGE_COACH_PRE_SURVEY_ID = '987'
+    settings.SURVEY_987_LINK = 'x'
     settings.SURVEY_987_ACTIVE = ''
 
     notcoach = EducatorFactory()

--- a/surveys/__init__.py
+++ b/surveys/__init__.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 
 class Survey:
 
@@ -9,6 +10,12 @@ class Survey:
 
     def __init__(self, id, *args, **kwargs):
         self.id = id
+        if not self.id:
+            raise ImproperlyConfigured('Can not instantiate Survey without a valid id')
+        try:
+            self.link
+        except AttributeError:
+            raise ImproperlyConfigured('SURVEY_%s_LINK must be properly configured' % self.id)
 
     def __getattr__(self, name):
         name = name.upper()

--- a/surveys/tests/test_survey.py
+++ b/surveys/tests/test_survey.py
@@ -2,12 +2,11 @@ import mock
 import pytest
 from .. import get_survey
 
-def test_unconfigured_survey_is_inactive():
+def test_active_defaults_to_false():
     with mock.patch('surveys.settings', autospec=True) as settings:
         settings.SURVEY_123_LINK = "link"
 
         assert not get_survey("123").active
-        assert not get_survey("456").active
 
 def test_get_survey():
     with mock.patch('surveys.settings', autospec=True) as settings:

--- a/surveys/tests/test_survey_complete_view.py
+++ b/surveys/tests/test_survey_complete_view.py
@@ -9,6 +9,7 @@ def test_completes(client, settings):
     settings.ALLOW_SURVEY_RESPONSE_HOOK_BYPASS=False
     user = UserFactory(username='username', password='password')
     sr = SurveyResponseFactory(user=user)
+    setattr(settings, "SURVEY_%s_LINK" % sr.survey_id, "link")
     assert sr.unknown
 
     client.login(username='username', password='password')
@@ -23,6 +24,7 @@ def test_completes(client, settings):
 def test_redirects_as_configured(client, settings):
     settings.ALLOW_SURVEY_RESPONSE_HOOK_BYPASS=False
     settings.SURVEY_987_REDIRECT="logout"
+    settings.SURVEY_987_LINK="link"
 
     user = UserFactory(username='username', password='password')
     sr = SurveyResponseFactory(user=user, survey_id=987)
@@ -39,6 +41,7 @@ def test_redirects_as_configured(client, settings):
 def test_sets_message_as_configured(client, settings):
     settings.ALLOW_SURVEY_RESPONSE_HOOK_BYPASS=False
     settings.SURVEY_987_MESSAGE="great job everybody"
+    settings.SURVEY_987_LINK="link"
 
     user = UserFactory(username='username', password='password')
     sr = SurveyResponseFactory(user=user, survey_id=987)
@@ -56,6 +59,7 @@ def test_no_referer(client, settings):
     settings.ALLOW_SURVEY_RESPONSE_HOOK_BYPASS=False
     user = UserFactory(username='username', password='password')
     sr = SurveyResponseFactory(user=user)
+    setattr(settings, "SURVEY_%s_LINK" % sr.survey_id, "link")
 
     client.login(username='username', password='password')
     client.get(


### PR DESCRIPTION
Surveys will fail faster and report the problem, rather than giving a very cryptic error down the line when `survey.url` is accessed.

<!---
@huboard:{"custom_state":"archived"}
-->
