### PR TITLE
#2150 remove broken canonical domain middleware

### DIFF
--- a/curiositymachine/middleware.py
+++ b/curiositymachine/middleware.py
@@ -23,14 +23,6 @@ def whitelisted(view, *listnames):
             return True
     return False
 
-class CanonicalDomainMiddleware(MiddlewareMixin):
-    """
-    Redirects to CANONICAL_DOMAIN from other domains if set
-    """
-    def process_request(self, request):
-        if settings.CANONICAL_DOMAIN and not request.META['HTTP_HOST'] == settings.CANONICAL_DOMAIN:
-            return HttpResponseRedirect('http://{}/{}'.format(settings.CANONICAL_DOMAIN, escape_uri_path(request.get_full_path()))) # might as well redirect to http as sslify will then catch requests if appropriate
-
 class LoginRequiredMiddleware(MiddlewareMixin):
     """
     Redirects to login if view isn't in 'public' or 'maybe_public' whitelists, or view has raised LoginRequired

--- a/curiositymachine/settings.py
+++ b/curiositymachine/settings.py
@@ -48,10 +48,6 @@ SITE_URL = os.getenv('SITE_URL', '')
 ADMINS = tuple([("Curiosity Machine Admin", email) for email in os.getenv("ADMINS", '').split(',')])
 INTERNAL_IPS = os.getenv('INTERNAL_IPS', '').split(',') if os.getenv('INTERNAL_IPS') else []
 
-# Canonical domain -- if this is set, all requests not to this domain will be forwarded to this domain
-# this should be a bare domain -- no scheme or route! For instance, www.example.com and not http://www.example.com
-CANONICAL_DOMAIN = os.getenv("CANONICAL_DOMAIN", None)
-
 COMPRESS_ENABLED = os.environ.get('COMPRESS_ENABLED', False) # no compression by default for now
 
 WEBPACK_LOADER = {
@@ -117,7 +113,6 @@ SITE_ID = 1
 
 MIDDLEWARE = [
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-    'curiositymachine.middleware.CanonicalDomainMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
With DNS reconfigured, this was redirecting https://curiositymachine.org to https://www.curiositymachine.org//

Not a huge deal, but I thought I'd get rid of the double-slash and ended up realizing that this middleware isn't even handling things correctly in more complicated cases, so I think we're fine without it.

As a note, `ALLOWED_DOMAINS` included curiositymachine.herokuapp.com and beta.curiositymachine.org for some reason. Now it's just curiositymachine.org and www.curiositymachine.org.

<!---
@huboard:{"custom_state":"archived"}
-->
