### PR TITLE
#2195 simplify profile chooser screen 

### DIFF
--- a/educators/forms.py
+++ b/educators/forms.py
@@ -46,17 +46,12 @@ class EducatorProfileForm(RelatedModelFormMixin, ProfileModelForm):
     first_name = forms.CharField(required=True)
     last_name = forms.CharField(required=True)
 
-    coach_signup = forms.BooleanField(required=False, widget=forms.HiddenInput)
-
     def save_related(self, obj):
         obj = super().save_related(obj)
 
         if self.cleaned_data.get("image_url"):
             img = Image.from_source_with_job(self.cleaned_data['image_url']['url'])
             obj.image = img
-
-        if self.cleaned_data.get("coach_signup"):
-            Member.objects.get_or_create(user=self.user, membership_id=settings.AICHALLENGE_COACH_MEMBERSHIP_ID)
 
         return obj
 

--- a/educators/templates/educators/educatorprofile_form.html
+++ b/educators/templates/educators/educatorprofile_form.html
@@ -14,7 +14,6 @@
 {% endblock %}
 
 {% block fields %}
-  {% render_field form.coach_signup %}
   <div class="text-center avatar-settings">
     {% block avatar %}{{ block.super }}{% endblock %}
     {% form_group form.image_url field_class="btn btn-primary" %}

--- a/educators/views.py
+++ b/educators/views.py
@@ -41,12 +41,6 @@ class CreateView(EditProfileMixin, CreateView):
     form_class = EducatorProfileForm
     success_url = lazy(reverse, str)("educators:home")
 
-    def get_initial(self):
-        initial = super().get_initial()
-        if "coach_signup" in self.request.GET:
-            initial["coach_signup"] = True
-        return initial
-
 create = not_for_role(UserRole.educator, redirect="educators:edit_profile")(CreateView.as_view())
 
 class EditView(EditProfileMixin, UpdateView):

--- a/profiles/templates/profiles/choose_profile.html
+++ b/profiles/templates/profiles/choose_profile.html
@@ -27,14 +27,14 @@
       </div>
       <div class="row mt-4">
         <div class="col-8 offset-2 col-md-5 offset-md-0">
-          <a href="{% url "educators:create_profile" %}?coach_signup=1">
-            <img src="{% static "images/educator.png" %}" alt="Coach">
+          <a href="{% url "educators:create_profile" %}">
+            <img src="{% static "images/educator.png" %}" alt="Mentor">
           </a>
         </div>
         <div class="col-12 col-md-7 my-5">
-          <a class="btn btn-primary" href="{% url "educators:create_profile" %}?coach_signup=1">Make a coach account</a>
+          <a class="btn btn-primary" href="{% url "educators:create_profile" %}">Make a mentor account</a>
           <p class="mt-2">
-            Coaches lead students and families through the challenge. Create this account if you plan to organize the challenge for groups.
+            Mentors lead students and families through the challenge. Create this account if you plan to organize the challenge for groups.
           </p>
         </div>
       </div>
@@ -54,14 +54,4 @@
     </div>
   </div>
 
-  {% url "educators:create_profile" as educator_url %}
-  <div class="card mb-4">
-    <div class="card-body text-center text-md-left">
-      <h4>Educator</h4>
-      <p>
-        Find resources to teach engineering challenges.
-      </p>
-      <a class="btn btn-primary" href="{{ educator_url }}">I am an educator</a>
-    </div>
-  </div>
 {% endblock %}


### PR DESCRIPTION
This removes the distinction between coach and educator signups. It doesn't fully remove the coach-related code or config, which is probably better done in #2220.

<!---
@huboard:{"custom_state":"archived"}
-->
