### PR TITLE
rework migration dependencies due to migration ordering in staging

### DIFF
--- a/challenges/migrations/0063_remove_challenge_mentor_guide.py
+++ b/challenges/migrations/0063_remove_challenge_mentor_guide.py
@@ -9,6 +9,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('challenges', '0062_remove_challenge_core'),
+        ('cmcomments', '0015_auto_20170814_1117'),
     ]
 
     operations = [

--- a/cmcomments/migrations/0015_auto_20170814_1117.py
+++ b/cmcomments/migrations/0015_auto_20170814_1117.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ('cmcomments', '0014_auto_20160506_1138'),
         ('notifications', '0005_auto_20160504_1520'),
-        ('challenges', '0063_remove_challenge_mentor_guide'),
+        ('challenges', '0006_auto_20140423_1320'),
     ]
 
     operations = [


### PR DESCRIPTION
Staging deployment failed for #2223 with `django.db.migrations.exceptions.InconsistentMigrationHistory: Migration cmcomments.0015_auto_20170814_1117 is applied before its dependency challenges.0063_remove_challenge_mentor_guide on database 'default'.`

This should fix that. Opening the PR for an audit trail for @rachwyatt to see, but immediately merging to get staging up and running again.

<!---
@huboard:{"custom_state":"archived"}
-->
