### PR TITLE
#2251 rq workers

### DIFF
--- a/subprocess_workers.py
+++ b/subprocess_workers.py
@@ -3,9 +3,11 @@ import time
 from subprocess import Popen
 
 NUMBER_OF_WORKERS = int(os.environ.get('RQ_CONCURRENT_WORKERS', 4))
+SCHEDULER_CMD = os.environ.get('RQ_SCHEDULER_COMMAND', 'python -u manage.py rqscheduler --queue default -i 10')
+WORKER_CMD = os.environ.get('RQ_WORKER_COMMAND', 'python -u manage.py rqworker default --worker-class rq.worker.HerokuWorker')
 
-commands = ['python -u manage.py rqscheduler --queue default -i 10']
-commands += ['python -u manage.py rqworker default --worker-class rq.worker.HerokuWorker'] * NUMBER_OF_WORKERS
+commands = [SCHEDULER_CMD]
+commands += [WORKER_CMD] * NUMBER_OF_WORKERS
 
 processes = [Popen(cmd, shell=True) for cmd in commands]
 


### PR DESCRIPTION
I think this is a simpler, more robust `subprocess_workers.py`. It relies on the `rqscheduler` and `rqworker` management commands to run the scheduler and workers, and does some simple subprocess management such that any one subprocess finishing will terminate the rest. On Heroku, this should allow the infrastructure to reboot the entire set of workers and the scheduler if any one worker fails.

I almost never run `subprocess_workers.py` locally, but note that if you did want to, you may need to customize `RQ_WORKER_COMMAND` to avoid using the `HerokuWorker` worker class. On OSX at least, it errors out because it doesn't know about the proper signals.

<!---
@huboard:{"custom_state":"archived"}
-->
