### PR TITLE
Avoid using .querset directly in ViewSet

### DIFF
--- a/lessons/views/lesson_viewset.py
+++ b/lessons/views/lesson_viewset.py
@@ -29,7 +29,7 @@ class LessonViewSet(viewsets.GenericViewSet):
         return Response({'lesson': lesson}, template_name=template_name)
 
     def list(self, request):
-        lessons = self.queryset
+        lessons = self.get_queryset()
         return Response({'lessons': lessons}, template_name="lessons/lessons.html")
 
 lessons = LessonViewSet.as_view({'get':'list'})


### PR DESCRIPTION
This fixes a caching bug where the `/lessons/lesson/` page would cache the queryset until the server was restarted, regardless of changes done through the admin.

<!---
@huboard:{"custom_state":"archived"}
-->
