### PR TITLE
#2425 make google analytics context processor a bit smarter

### DIFF
--- a/curiositymachine/context_processors/google_analytics.py
+++ b/curiositymachine/context_processors/google_analytics.py
@@ -25,15 +25,7 @@ def google_analytics(request):
     elif request.user.is_staff:
         usertype = "Staff"
     else:
-        usertype = ""
-        if request.user.extra.is_student:
-            usertype += "Student"
-        if request.user.extra.is_educator:
-            usertype += "Educator"
-
-        if not usertype:
-            usertype = "Other"
-            logger.warning("User categorized as Other for Google Analytics: {}".format(request.user.username))
+        usertype = request.user.extra.role_name.capitalize()
 
     userid = None
     if request.user.is_authenticated:


### PR DESCRIPTION
This should still send students and educators across as "Student" and "Educator", and also handle any future profile types like "Family" without needing to be manually updated.

<!---
@huboard:{"custom_state":"archived"}
-->
